### PR TITLE
Enabled read-only exports for calendars (.ics)

### DIFF
--- a/Core/Frameworks/Baikal/WWWRoot/cal.php
+++ b/Core/Frameworks/Baikal/WWWRoot/cal.php
@@ -65,7 +65,7 @@ $server->setBaseUri(BAIKAL_CAL_BASEURI);
 $server->addPlugin(new Sabre_DAV_Auth_Plugin($authBackend, BAIKAL_AUTH_REALM));
 $server->addPlugin(new Sabre_DAVACL_Plugin());
 $server->addPlugin(new Sabre_CalDAV_Plugin());
-
+$server->addPlugin(new Sabre_CalDAV_ICSExportPlugin());
 
 # And off we go!
 $server->exec();


### PR DESCRIPTION
Appending "?export" to the end of the url will now automatically trigger the download of an iCalendar data file of your calendar:
http://hostname/cal.php/calendars/username/default?export.

(see also https://code.google.com/p/sabredav/wiki/ICSExportPlugin)
