### PR TITLE
fix nginx configuration parameter

### DIFF
--- a/Specific/virtualhosts/baikal.nginx
+++ b/Specific/virtualhosts/baikal.nginx
@@ -16,7 +16,7 @@ server {
         try_files $fastcgi_script_name =404;
         fastcgi_split_path_info  ^(.+\.php)(.*)$;
         fastcgi_pass   unix:/var/run/php-fpm/php-fpm.sock;
-        fastcgi_param  SCRIPT_FILENAME  $document_root/$fastcgi_script_name;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         fastcgi_param  PATH_INFO        $fastcgi_path_info;
         include        /etc/nginx/fastcgi_params;
     }


### PR DESCRIPTION
This cause invalid links when hosted on a sub-uri like /dav/. The
Flake frameworks generates links to //dav/admin, which points to
nowhere.
