### PR TITLE
HTTP Basic auth

### DIFF
--- a/Core/Frameworks/Baikal/Core/PDOBasicAuth.php
+++ b/Core/Frameworks/Baikal/Core/PDOBasicAuth.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Baikal\Core;
+
+/**
+ * This is an authentication backend that uses a database to manage passwords.
+ *
+ * Format of the database tables must match to the one of \Sabre\DAV\Auth\Backend\PDO
+ *
+ * @copyright Copyright (C) 2013 Lukasz Janyst. All rights reserved.
+ * @author Lukasz Janyst <ljanyst@buggybrain.net>
+ * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ */
+class PDOBasicAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
+
+    /**
+     * Reference to PDO connection
+     *
+     * @var PDO
+     */
+    protected $pdo;
+
+    /**
+     * PDO table name we'll be using
+     *
+     * @var string
+     */
+    protected $tableName;
+
+    /**
+     * Authentication realm
+     *
+     * @var string
+     */
+    protected $authRealm;
+
+    /**
+     * Creates the backend object.
+     *
+     * If the filename argument is passed in, it will parse out the specified file fist.
+     *
+     * @param PDO $pdo
+     * @param string $tableName The PDO table name to use
+     */
+    public function __construct(\PDO $pdo, $authRealm, $tableName = 'users') {
+
+        $this->pdo = $pdo;
+        $this->tableName = $tableName;
+        $this->authRealm = $authRealm;
+    }
+
+    /**
+     * Validates a username and password
+     *
+     * This method should return true or false depending on if login
+     * succeeded.
+     *
+     * @param string $username
+     * @param string $password
+     * @return bool
+     */
+    public function validateUserPass($username, $password) {
+
+        $stmt = $this->pdo->prepare('SELECT username, digesta1 FROM '.$this->tableName.' WHERE username = ?');
+        $stmt->execute(array($username));
+        $result = $stmt->fetchAll();
+
+
+        if (!count($result)) return false;
+
+        $hash = md5( $username . ':' . $this->authRealm . ':' . $password );
+        if( $result[0]['digesta1'] == $hash )
+        {
+            $this->currentUser = $username;
+            return true;
+        }
+        return false;
+
+    }
+
+}

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -41,6 +41,10 @@ class Standard extends \Baikal\Model\Config {
 			"type" => "boolean",
 			"comment" => "CalDAV ON/OFF switch; default TRUE",
 		),
+		"BAIKAL_DAV_AUTH_TYPE" => array(
+			"type" => "string",
+			"comment" => "HTTP authentication type for WebDAV; default Digest"
+		),
 		"BAIKAL_ADMIN_ENABLED" => array(
 			"type" => "boolean",
 			"comment" => "Baïkal Web Admin ON/OFF switch; default TRUE",
@@ -60,6 +64,7 @@ class Standard extends \Baikal\Model\Config {
 		"PROJECT_TIMEZONE" => "Europe/Paris",
 		"BAIKAL_CARD_ENABLED" => TRUE,
 		"BAIKAL_CAL_ENABLED" => TRUE,
+		"BAIKAL_DAV_AUTH_TYPE" => "Digest",
 		"BAIKAL_ADMIN_ENABLED" => TRUE,
 		"BAIKAL_ADMIN_AUTOLOCKENABLED" => FALSE,
 		"BAIKAL_ADMIN_PASSWORDHASH" => ""
@@ -84,6 +89,12 @@ class Standard extends \Baikal\Model\Config {
 		$oMorpho->add(new \Formal\Element\Checkbox(array(
 			"prop" => "BAIKAL_CARD_ENABLED",
 			"label" => "Enable CardDAV"
+		)));
+
+		$oMorpho->add(new \Formal\Element\Listbox(array(
+			"prop" => "BAIKAL_DAV_AUTH_TYPE",
+			"label" => "WebDAV authentication type",
+			"options" => array( "Digest", "Basic" )
 		)));
 		
 		$oMorpho->add(new \Formal\Element\Password(array(
@@ -192,6 +203,9 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 
 # CalDAV ON/OFF switch; default TRUE
 define("BAIKAL_CAL_ENABLED", TRUE);
+
+# WebDAV authentication type; default Digest
+define("BAIKAL_DAV_AUTH_TYPE", "Digest")
 
 # Baïkal Web Admin ON/OFF switch; default TRUE
 define("BAIKAL_ADMIN_ENABLED", TRUE);

--- a/Core/Frameworks/Baikal/WWWRoot/cal.php
+++ b/Core/Frameworks/Baikal/WWWRoot/cal.php
@@ -47,7 +47,11 @@ if(!defined("BAIKAL_CAL_ENABLED") || BAIKAL_CAL_ENABLED !== TRUE) {
 }
 
 # Backends
-$authBackend = new \Sabre\DAV\Auth\Backend\PDO($GLOBALS["DB"]->getPDO());
+if( BAIKAL_DAV_AUTH_TYPE == "Basic" )
+    $authBackend = new \Baikal\Core\PDOBasicAuth($GLOBALS["DB"]->getPDO(), BAIKAL_AUTH_REALM);
+else
+    $authBackend = new \Sabre\DAV\Auth\Backend\PDO($GLOBALS["DB"]->getPDO());
+
 $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($GLOBALS["DB"]->getPDO());
 $calendarBackend = new \Sabre\CalDAV\Backend\PDO($GLOBALS["DB"]->getPDO());
 

--- a/Core/Frameworks/Baikal/WWWRoot/card.php
+++ b/Core/Frameworks/Baikal/WWWRoot/card.php
@@ -48,7 +48,11 @@ if(!defined("BAIKAL_CARD_ENABLED") || BAIKAL_CARD_ENABLED !== TRUE) {
 }
 
 # Backends
-$authBackend = new \Sabre\DAV\Auth\Backend\PDO($GLOBALS["DB"]->getPDO());
+if( BAIKAL_DAV_AUTH_TYPE == "Basic" )
+    $authBackend = new \Baikal\Core\PDOBasicAuth($GLOBALS["DB"]->getPDO(), BAIKAL_AUTH_REALM);
+else
+    $authBackend = new \Sabre\DAV\Auth\Backend\PDO($GLOBALS["DB"]->getPDO());
+
 $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($GLOBALS["DB"]->getPDO());
 $carddavBackend = new \Sabre\CardDAV\Backend\PDO($GLOBALS["DB"]->getPDO()); 
 


### PR DESCRIPTION
Hey there,

   I have been having quite a lot of troubles using Baikal (sabredav) with digest authentication, it seems to be quite unpredictable with some clients. This patch adds a switch to use basic auth instead.

   I tested it with 0.2.4 flat, because I have not been able to run the HEAD of the master branch.

Cheers,
   Lukasz
