### PR TITLE
added rewrite rules for nginx host

### DIFF
--- a/Specific/virtualhosts/baikal.nginx
+++ b/Specific/virtualhosts/baikal.nginx
@@ -4,6 +4,9 @@ server {
 
     root  /var/www/dav.mydomain.com;
     index index.php;
+
+	rewrite ^/.well-known/caldav /cal.php redirect;
+	rewrite ^/.well-known/carddav /card.php redirect;
     
     charset utf-8;
 


### PR DESCRIPTION
- No further strings like "cal.php/principals/$user" are necessary
- iOS / OSX can use 'dav.domain.com' directly as cal/card dav server
