### PR TITLE
Removed duplicated BAIKAL_DAV_AUTH_TYPE in generated default config

### DIFF
--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -204,9 +204,6 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 # CalDAV ON/OFF switch; default TRUE
 define("BAIKAL_CAL_ENABLED", TRUE);
 
-# WebDAV authentication type; default Digest
-define("BAIKAL_DAV_AUTH_TYPE", "Digest")
-
 # Baïkal Web Admin ON/OFF switch; default TRUE
 define("BAIKAL_ADMIN_ENABLED", TRUE);
 


### PR DESCRIPTION
The constant BAIKAL_DAV_AUTH_TYPE is added twice when installing a new instance. This breaks the installation process.
