### PR TITLE
Prevent PHP from parsing your MySQL credentials

### DIFF
--- a/Core/Frameworks/Baikal/Model/Config.php
+++ b/Core/Frameworks/Baikal/Model/Config.php
@@ -157,7 +157,7 @@ abstract class Config extends \Flake\Core\Model\NoDb {
 			# We replace value by it's native PHP notation
 			switch($this->aConstants[$prop]["type"]) {
 				case "string": {
-					$sValue = '"' . addcslashes($sValue, "\"\\\0\n\r") . '"';	# Add quotes, and escape " and all string-termination chars
+					$sValue = '\'' . addcslashes($sValue, "\"\\\0\n\r") . '\'';	# Add quotes, and escape " and all string-termination chars
 					break;
 				}
 				case "integer": {
@@ -179,7 +179,7 @@ abstract class Config extends \Flake\Core\Model\NoDb {
 					break;
 				}
 				default: {
-					$sValue = '""';
+					$sValue = '\'\'';
 					break;
 				}
 			}


### PR DESCRIPTION
## Problem

If you use a $-character in your MySQL username/password/dbname, it won't be escaped before writing it into the configuration file and because of the fact, that Baikal currently uses double-quotes for strings, PHP parses the string, finds a variable and tries to resolve it which cannot be found. This causes a "undefined variable $bug" E_NOTICE.
### Installation

```
[...]
MySQL password: this_is_a_$bug
[...]
```
### Configuration (config.system.php)

``` php
// ...

define("PROJECT_DB_MYSQL_PASSWORD", "this_is_a_$bug");

// ...
```
### Error

> Notice: Undefined variable: bug in [...]/Specific/config.system.php on line 66
