### PR TITLE
Update Auth.php

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -59,7 +59,7 @@ class Auth {
 			if((time() - $iTime) < 3600) {
 				# file has been created/updated less than an hour ago; update it's mtime
 				if(is_writable($sEnableFile)) {
-					@touch($sEnableFile);
+					@file_put_contents($sEnableFile, '');
 				}
 				$bLocked = FALSE;
 			} else {


### PR DESCRIPTION
Fixed an issue when we try to install baikal on Synology NAS.
touch() function is not supported on this hardware.

use file_put_contents () does not interfere with the logic of the code and provides better compatibility as touch() also has other problems on Windows OS

http://synology.com

http://blog.idleman.fr/installez-votre-synchronisateurs-de-contacts-chez-vous-avec-baikal/
