### PR TITLE
Typo in error messages

### DIFF
--- a/Core/Frameworks/Baikal/WWWRoot/cal.php
+++ b/Core/Frameworks/Baikal/WWWRoot/cal.php
@@ -36,7 +36,7 @@ if(file_exists(getcwd() . "/Core")) {
 }
 
 if(!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependancies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
+	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/Baikal/WWWRoot/card.php
+++ b/Core/Frameworks/Baikal/WWWRoot/card.php
@@ -36,7 +36,7 @@ if(file_exists(getcwd() . "/Core")) {
 }
 
 if(!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependancies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
+	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/Baikal/WWWRoot/index.php
+++ b/Core/Frameworks/Baikal/WWWRoot/index.php
@@ -35,7 +35,7 @@ if(file_exists(getcwd() . "/Core")) {
 }
 
 if(!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependancies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
+	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -40,7 +40,7 @@ if(file_exists(dirname(getcwd()). "/Core")) {
 }
 
 if(!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependancies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
+	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -40,7 +40,7 @@ if(file_exists(dirname(dirname(getcwd())) . "/Core")) {
 }
 
 if(!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependancies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
+	die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. Please, execute "<strong>composer install</strong>" in the folder where you installed Ba&iuml;kal.');
 }
 
 require PROJECT_PATH_ROOT . "vendor/autoload.php";


### PR DESCRIPTION
## Before

> **Incomplete installation**
> Baïkal _[dependancies]_ have not been installed. Please, execute "composer install" in the folder where you installed Baïkal.
## After

> **Incomplete installation**
> Baïkal _[dependencies]_ have not been installed. Please, execute "composer install" in the folder where you installed Baïkal.
