### PR TITLE
Improve application security

### DIFF
--- a/Core/Frameworks/Baikal/WWWRoot/cal.php
+++ b/Core/Frameworks/Baikal/WWWRoot/cal.php
@@ -24,6 +24,10 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
+ini_set("session.cookie_httponly", 1);
+ini_set("display_errors", 0);
+ini_set("log_errors", 1);
+
 define("BAIKAL_CONTEXT", TRUE);
 define("PROJECT_CONTEXT_BASEURI", "/");
 

--- a/Core/Frameworks/Baikal/WWWRoot/index.php
+++ b/Core/Frameworks/Baikal/WWWRoot/index.php
@@ -23,6 +23,11 @@
 *
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
+
+ini_set("session.cookie_httponly", 1);
+ini_set("display_errors", 0);
+ini_set("log_errors", 1);
+
 define("BAIKAL_CONTEXT", TRUE);
 define("PROJECT_CONTEXT_BASEURI", "/");
 

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -24,7 +24,9 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-ini_set("display_errors", 1);
+ini_set("session.cookie_httponly", 1);
+ini_set("display_errors", 0);
+ini_set("log_errors", 1);
 error_reporting(E_ALL);
 
 define("BAIKAL_CONTEXT", TRUE);

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -24,7 +24,9 @@
 *  This copyright notice MUST APPEAR in all copies of the script!
 ***************************************************************/
 
-ini_set("display_errors", 1);
+ini_set("session.cookie_httponly", 1);
+ini_set("display_errors", 0);
+ini_set("log_errors", 1);
 error_reporting(E_ALL);
 
 define("BAIKAL_CONTEXT", TRUE);

--- a/Core/Frameworks/Flake/Controller/Page.php
+++ b/Core/Frameworks/Flake/Controller/Page.php
@@ -73,6 +73,9 @@ class Page extends \Flake\Core\Render\Container {
 	
 	public function injectHTTPHeaders() {
 		header("Content-Type: text/html; charset=UTF-8");
+
+		header("X-Frame-Options: DENY");	# Prevent Clickjacking attacks
+		header("X-Content-Type-Options: nosniff");	# Prevent code injection via mime type sniffing
 	}
 	
 	public function render() {


### PR DESCRIPTION
#### Improve application security:
- Make session cookies only available via HTTP (prevent access from JavaScript)
- only log PHP errors instead of displaying them in production.
  Displaying errors may give attackers hints how to exploit the application
#### Set HTTP headers:

**X-Frame-Options: DENY**
Prevent Clickjacking attacks, see: http://en.wikipedia.org/wiki/Clickjacking

**X-Content-Type-Options: nosniff**
Prevent code injection via mime type sniffing
