### PR TITLE
Update installation docs: Limit rights for Baïkal's MySQL user (for security reasons)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -317,12 +317,12 @@ mysql -u root -p #password#
 
 ```mysql
 CREATE DATABASE baikal;
-GRANT ALL PRIVILEGES ON baikal.* TO 'baikal'@'localhost' IDENTIFIED BY 'password' WITH GRANT OPTION;
+GRANT DELETE, INSERT, SELECT, UPDATE ON baikal.* TO 'baikal'@'localhost' IDENTIFIED BY '#password#';
 exit
 ```
 
 ```sh
-mysql -u baikal -p #password# -D baikal < /var/www/baikal/Core/Resources/Db/MySQL/db.sql
+mysql -u root -p #password# -D baikal < /var/www/baikal/Core/Resources/Db/MySQL/db.sql
 sudo touch /var/www/baikal/Specfic/ENABLE_INSTALL
 sudo chown www-data /var/www/baikal/Specific/ENABLE_INSTALL
 sudo vi /etc/apache2/sites-available/baikal


### PR DESCRIPTION
I fixed the line endings (Unix), that's why the diff is completely red.
But important changes are in 6cd9e2a and c83db79, the single diffs will make it clear what changed.
