### PR TITLE
Added possibility to edit calendar color

### DIFF
--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -169,7 +169,8 @@ class Calendar extends \Flake\Core\Model\Db {
             "popover" => array(
                     "title" => "Calendar color",
                     "content" => "This is the color that will be displayed in your CalDAV client.</br>".
-                    "Must be supplied in format '#RRGGBBAA' with hexadecimal values. This value is optional.",
+                    "Must be supplied in format '#RRGGBBAA' (alpha channel optional) with hexadecimal values.</br>".
+                    "This value is optional.",
             )
         )));
 

--- a/Core/Frameworks/Formal/Form.php
+++ b/Core/Frameworks/Formal/Form.php
@@ -317,7 +317,7 @@ class Form {
 
 	public function validateColor($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
 		if(!empty($sValue) && !preg_match("/^#[a-fA-F0-9]{6}([a-fA-F0-9]{2})?$/", $sValue)) {
-			return "<strong>" . $oElement->option("label") . "</strong> is not a valid color with format '#RRGGBBAA' in hexadecimal values.";
+			return "<strong>" . $oElement->option("label") . "</strong> is not a valid color with format '#RRGGBB' or '#RRGGBBAA' in hexadecimal values.";
 		}
 		
 		return TRUE;


### PR DESCRIPTION
Make it possible that a client (e.g. DAVdroid) can display a default color for each calendar (comparable with ownCloud).
For compatibility an empty color string is accepted, default is still empty string.
