### PR TITLE
Fixed typo. allright -> alright

### DIFF
--- a/Core/Frameworks/Baikal/WWWRoot/index.php
+++ b/Core/Frameworks/Baikal/WWWRoot/index.php
@@ -59,6 +59,6 @@ require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></meta>
 </head>
 <body>
-	<h2>Baïkal is running allright.</h2>
+	<h2>Baïkal is running alright.</h2>
 </body>
 </html>


### PR DESCRIPTION
One "l" to much.
