### PR TITLE
Add .well-known redirects to .htaccess

### DIFF
--- a/html/.htaccess
+++ b/html/.htaccess
@@ -14,3 +14,8 @@
 <IfModule mod_expires.c>
 	ExpiresActive Off
 </IfModule>
+
+<IfModule mod_alias.c>
+	Redirect 301 /.well-known/caldav /dav.php
+	Redirect 301 /.well-known/carddav /dav.php
+</IfModule>

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -16,6 +16,6 @@
 </IfModule>
 
 <IfModule mod_alias.c>
-	Redirect 301 /.well-known/caldav /dav.php
-	Redirect 301 /.well-known/carddav /dav.php
+	Redirect 308 /.well-known/caldav /dav.php
+	Redirect 308 /.well-known/carddav /dav.php
 </IfModule>


### PR DESCRIPTION
You should rather use `mod_alias` than `mod_rewrite` to accomplish simple redirects. I know that this redirect is already included in Baikal's installation instructions, however, it's common practice to include `.well-known` redirects in the `.htaccess` rather than the vhost config. Due to the fact that the vhost config is often managed by some sort of web hosting control panel, users easily overlook this instruction and wonder why Baikal isn't working with their CalDAV/CardDAV client.