### PR TITLE
Fix Travis Build by using Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
 services:
   - mysql
 
+dist: trusty
 sudo: false
 
 before_script:


### PR DESCRIPTION
* HHVM is no longer supported on Ubuntu Precise
* Last Build failed: https://travis-ci.org/fruux/Baikal/builds/265898086