### PR TITLE
Upgrade each() to foreach()

### DIFF
--- a/Core/Frameworks/Flake/Controller/Cli.php
+++ b/Core/Frameworks/Flake/Controller/Cli.php
@@ -39,9 +39,8 @@ class Cli extends \Flake\Core\Render\Container {
     }
 
     function execute() {
-        reset($this->aSequence);
-        while (list($sKey, ) = each($this->aSequence)) {
-            $this->aSequence[$sKey]["block"]->execute();
+        foreach ($this->aSequence as $aStep) {
+            $aStep["block"]->execute();
         }
     }
 

--- a/Core/Frameworks/Flake/Core/Render/Container.php
+++ b/Core/Frameworks/Flake/Core/Render/Container.php
@@ -58,23 +58,20 @@ abstract class Container extends \Flake\Core\Controller {
     }
 
     function execute() {
-        reset($this->aSequence);
-        while (list($sKey, ) = each($this->aSequence)) {
-            $this->aSequence[$sKey]["block"]->execute();
+        foreach ($this->aSequence as $aStep) {
+            $aStep["block"]->execute();
         }
     }
 
     protected function renderBlocks() {
         $aHtml = [];
-        reset($this->aSequence);
-        while (list($sKey, ) = each($this->aSequence)) {
+        foreach ($this->aSequence as $sKey => $aStep) {
             $this->aSequence[$sKey]["rendu"] = $this->aSequence[$sKey]["block"]->render();
         }
 
         $aHtml = [];
-        reset($this->aBlocks);
-        while (list($sZone, ) = each($this->aBlocks)) {
-            $aHtml[$sZone] = implode("", $this->aBlocks[$sZone]);
+        foreach ($this->aBlocks as $sZone => $aBlock) {
+            $aHtml[$sZone] = implode("", $aBlock);
         }
 
         reset($aHtml);

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -122,7 +122,7 @@ class Framework extends \Flake\Core\Framework {
             if (isset($_COOKIE) && is_array($_COOKIE)) { $process[] = &$_COOKIE;}
             if (isset($_REQUEST) && is_array($_REQUEST)) { $process[] = &$_REQUEST;}
 
-            while (list($key, $val) = each($process)) {
+            foreach ($process as $key => $val) {
                 foreach ($val as $k => $v) {
                     unset($process[$key][$k]);
                     if (is_array($v)) {

--- a/Core/Frameworks/Flake/Util/Router.php
+++ b/Core/Frameworks/Flake/Util/Router.php
@@ -59,10 +59,9 @@ abstract class Router extends \Flake\Core\FLObject {
 
         $aRoutes = $GLOBALS["ROUTER"]::getRoutes();
 
-        reset($aRoutes);
-        while (list($sRoute, ) = each($aRoutes)) {
-            if (str_replace("\\Route", "\\Controller", $aRoutes[$sRoute]) === $sController) {
-                return $sRoute;
+        foreach ($aRoutes as $sKey => $sRoute) {
+            if (str_replace("\\Route", "\\Controller", $sRoute) === $sController) {
+                return $sKey;
             }
         }
 

--- a/Core/Frameworks/Flake/Util/Tools.php
+++ b/Core/Frameworks/Flake/Util/Tools.php
@@ -75,7 +75,7 @@ class Tools extends \Flake\Core\FLObject {
         if (is_array($array_in))    {
             $result = '<table border="1" cellpadding="1" cellspacing="0" bgcolor="white">';
             if (!count($array_in))    {$result .= '<tr><td><font face="Verdana,Arial" size="1"><b>' . htmlspecialchars("EMPTY!") . '</b></font></td></tr>';}
-            while (list($key, $val) = each($array_in))    {
+            foreach ($array_in as $key => $val) {
                 $result .= '<tr><td valign="top"><font face="Verdana,Arial" size="1">' . htmlspecialchars((string)$key) . '</font></td><td>';
                 if (is_array($array_in[$key]))    {
                     $result .= \Flake\Util\Tools::view_array($array_in[$key]);


### PR DESCRIPTION
Related to https://github.com/sabre-io/Baikal/issues/711: `each()` is deprecated in PHP 7.2: https://wiki.php.net/rfc/deprecations_php_7_2

This PR replaces all the `each` with an equivalent `foreach` construction.
I've tried to stick to the local usage regarding variable naming.

There is one `each` remaing in [`Collection`](https://github.com/oliverpool/Baikal/blob/4a33ba6ca2cc19eeab484f1affb031e9d5273692/Core/Frameworks/Flake/Core/Collection.php#L66) but I'm not sure where it is called

