### PR TITLE
Added feature to log failed logins for admin

### DIFF
--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -28,7 +28,6 @@
 namespace Baikal\Core;
 
 class Tools {
-    const FAILED_LOGIN_LOG_PATH = PROJECT_PATH_ROOT . '/Specific/failed-logins.log';
     static function &db() {
         return $GLOBALS["pdo"];
     }
@@ -229,6 +228,7 @@ CODE;
     static function logFailureLogin() {
        $ip = self::getRemoteIp();
        $timestamp = self::getTimestamp();
-       file_put_contents(self::FAILED_LOGIN_LOG_PATH, $ip . ' ' . $timestamp . PHP_EOL, FILE_APPEND);
+       $failedLoginLogPath = PROJECT_PATH_ROOT . '/Specific/failed-logins.log';
+       file_put_contents($failedLoginLogPath, $ip . ' ' . $timestamp . PHP_EOL, FILE_APPEND);
     }
 }

--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -28,6 +28,7 @@
 namespace Baikal\Core;
 
 class Tools {
+    const FAILED_LOGIN_LOG_PATH = PROJECT_PATH_ROOT . '/Specific/failed-logins.log';
     static function &db() {
         return $GLOBALS["pdo"];
     }
@@ -212,5 +213,29 @@ CODE;
 
         reset($aZones);
         return $aZones;
+    }
+
+    static function timezones() {
+        $aZones = \DateTimeZone::listIdentifiers();
+
+        reset($aZones);
+        return $aZones;
+    }
+
+    private static function getRemoteIp() {
+      //In case we are using nginx proxy, we should look into HTTP_X_REAL_IP instead of REMOTE_ADDR
+       return isset($_SERVER['HTTP_X_REAL_IP'])
+          ? $_SERVER['HTTP_X_REAL_IP']
+          : $_SERVER['REMOTE_ADDR'];
+    }
+
+    private static function getTimestamp() {
+       return date_timestamp_get(date_create());
+    }
+
+    static function logFailureLogin() {
+       $ip = self::getRemoteIp();
+       $timestamp = self::getTimestamp();
+       file_put_contents(self::FAILED_LOGIN_LOG_PATH, $ip . ' ' . $timestamp . PHP_EOL, FILE_APPEND);
     }
 }

--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -230,7 +230,7 @@ CODE;
     }
 
     private static function getTimestamp() {
-       return date_timestamp_get(date_create());
+       return date('d/M/Y:h:i:s', time());
     }
 
     static function logFailureLogin() {

--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -215,13 +215,6 @@ CODE;
         return $aZones;
     }
 
-    static function timezones() {
-        $aZones = \DateTimeZone::listIdentifiers();
-
-        reset($aZones);
-        return $aZones;
-    }
-
     private static function getRemoteIp() {
       //In case we are using nginx proxy, we should look into HTTP_X_REAL_IP instead of REMOTE_ADDR
        return isset($_SERVER['HTTP_X_REAL_IP'])

--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -27,6 +27,8 @@
 
 namespace BaikalAdmin\Controller;
 
+use Baikal\Core\Tools;
+
 class Login extends \Flake\Core\Controller {
 
     function execute() {
@@ -42,6 +44,7 @@ class Login extends \Flake\Core\Controller {
                 "The login/password you provided is invalid. Please retry.",
                 "Authentication error"
             );
+            Tools::logFailureLogin();
         } elseif (self::justLoggedOut()) {
             $sMessage = \Formal\Core\Message::notice(
                 "You have been disconnected from your session.",


### PR DESCRIPTION
This addresses issue #662 specially when the nginx server is behind a proxy and make it almost impossible to configure it in a reliable way to log the real ip of the user. The added functionality is Tools class so it can be used for CalDav and CardDav features. I just don't know where to add it for them.