### PR TITLE
Fixed creating new users

### DIFF
--- a/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
@@ -33,7 +33,6 @@ class Calendar extends \Flake\Core\Model\Db {
     const LABELFIELD = "components";
 
     protected $aData = [
-        "synctoken"  => "",
         "components" => ""
     ];
 


### PR DESCRIPTION
The `synctoken` column is an integer. It is not used by the Baikal web interface, so we can simply remove it, so it is filled with default values by the database.

Closes #781 