### PR TITLE
Enable invitation plugin

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -169,6 +169,7 @@ class Server {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
             $this->server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
+            $this->server->addPlugin(new \Sabre\CalDAV\Schedule\IMipPlugin(BAIKAL_INVITE_FROM));
         }
         if ($this->enableCardDAV) {
             $this->server->addPlugin(new \Sabre\CardDAV\Plugin());

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -169,7 +169,9 @@ class Server {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
             $this->server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
-            $this->server->addPlugin(new \Sabre\CalDAV\Schedule\IMipPlugin(BAIKAL_INVITE_FROM));
+            if (defined("BAIKAL_INVITE_FROM") && BAIKAL_INVITE_FROM !== "") {
+                $this->server->addPlugin(new \Sabre\CalDAV\Schedule\IMipPlugin(BAIKAL_INVITE_FROM));
+            }
         }
         if ($this->enableCardDAV) {
             $this->server->addPlugin(new \Sabre\CardDAV\Plugin());

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -189,7 +189,7 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 define("BAIKAL_CAL_ENABLED", TRUE);
 
 # CalDAV invite From: mail address (comment or leave blank to disable notifications)
-define("BAIKAL_INVITE_FROM", "noreply@".\$_SERVER["SERVER_NAME"]);
+define("BAIKAL_INVITE_FROM", "noreply@\$_SERVER[SERVER_NAME]");
 
 # WebDAV authentication type; default Digest
 define("BAIKAL_DAV_AUTH_TYPE", "Digest");

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -177,6 +177,9 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 # CalDAV ON/OFF switch; default TRUE
 define("BAIKAL_CAL_ENABLED", TRUE);
 
+# CalDAV invite From: mail address
+define("BAIKAL_INVITE_FROM", 'noreply@'.$_SERVER['SERVER_NAME']);
+
 # WebDAV authentication type; default Digest
 define("BAIKAL_DAV_AUTH_TYPE", "Digest");
 

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -42,6 +42,10 @@ class Standard extends \Baikal\Model\Config {
             "type"    => "boolean",
             "comment" => "CalDAV ON/OFF switch; default TRUE",
         ],
+        "BAIKAL_INVITE_FROM" => [
+            "type"    => "string",
+            "comment" => "CalDAV invite From: mail address (comment or leave blank to disable notifications)",
+        ],
         "BAIKAL_DAV_AUTH_TYPE" => [
             "type"    => "string",
             "comment" => "HTTP authentication type for WebDAV; default Digest"
@@ -57,6 +61,7 @@ class Standard extends \Baikal\Model\Config {
         "PROJECT_TIMEZONE"          => "Europe/Paris",
         "BAIKAL_CARD_ENABLED"       => true,
         "BAIKAL_CAL_ENABLED"        => true,
+        "BAIKAL_INVITE_FROM"        => "",
         "BAIKAL_DAV_AUTH_TYPE"      => "Digest",
         "BAIKAL_ADMIN_PASSWORDHASH" => ""
     ];

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -178,7 +178,7 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 define("BAIKAL_CAL_ENABLED", TRUE);
 
 # CalDAV invite From: mail address
-define("BAIKAL_INVITE_FROM", 'noreply@'.$_SERVER['SERVER_NAME']);
+define("BAIKAL_INVITE_FROM", "noreply@".\$_SERVER["SERVER_NAME"]);
 
 # WebDAV authentication type; default Digest
 define("BAIKAL_DAV_AUTH_TYPE", "Digest");

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -177,7 +177,7 @@ define("BAIKAL_CARD_ENABLED", TRUE);
 # CalDAV ON/OFF switch; default TRUE
 define("BAIKAL_CAL_ENABLED", TRUE);
 
-# CalDAV invite From: mail address
+# CalDAV invite From: mail address (comment or leave blank to disable notifications)
 define("BAIKAL_INVITE_FROM", "noreply@".\$_SERVER["SERVER_NAME"]);
 
 # WebDAV authentication type; default Digest

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -78,13 +78,19 @@ class Standard extends \Baikal\Model\Config {
 
 
         $oMorpho->add(new \Formal\Element\Checkbox([
+            "prop"  => "BAIKAL_CARD_ENABLED",
+            "label" => "Enable CardDAV"
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Checkbox([
             "prop"  => "BAIKAL_CAL_ENABLED",
             "label" => "Enable CalDAV"
         ]));
 
-        $oMorpho->add(new \Formal\Element\Checkbox([
-            "prop"  => "BAIKAL_CARD_ENABLED",
-            "label" => "Enable CardDAV"
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"  => "BAIKAL_INVITE_FROM",
+            "label" => "Email invite sender address",
+            "help"  => "Leave empty to disable sending invite emails"
         ]));
 
         $oMorpho->add(new \Formal\Element\Listbox([


### PR DESCRIPTION
Hi,

This PR closes #746, closes #655, enabling invitation by mail.
Admin can configure From mail address used thanks to the `BAIKAL_INVITE_FROM` option.

Thank you 👍 