### PR TITLE
 Log failed accesses

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -189,7 +189,7 @@ class Server {
             // Applications may make their first call without auth so don't log these attempts
             // Pattern from sabre/dav/lib/DAV/Auth/Backend/AbstractDigest.php
             if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false) {
-                error_log('user not authorized: '.$e->getMessage());
+                error_log('user not authorized: Baikal DAV: '.$e->getMessage());
             }
         }
     }

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -186,6 +186,8 @@ class Server {
      */
     public function exception($e) {
         if ($e instanceof \Sabre\DAV\Exception\NotAuthenticated) {
+            // Applications may make their first call without auth so don't log these attempts
+            // Pattern from sabre/dav/lib/DAV/Auth/Backend/AbstractDigest.php
             if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false) {
                 error_log('user not authorized: '.$e->getMessage());
             }

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -175,6 +175,21 @@ class Server {
             $this->server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
         }
 
+        $this->server->on('exception', [$this, 'exception']);
+
+    }
+
+    /**
+     * Log failed accesses, for further processing by other tools (fail2ban)
+     *
+     * @return void
+     */
+    public function exception($e) {
+        if ($e instanceof \Sabre\DAV\Exception\NotAuthenticated) {
+            if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false) {
+                error_log('user not authorized: '.$e->getMessage());
+            }
+        }
     }
 
 }

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -184,12 +184,12 @@ class Server {
      *
      * @return void
      */
-    public function exception($e) {
+    function exception($e) {
         if ($e instanceof \Sabre\DAV\Exception\NotAuthenticated) {
             // Applications may make their first call without auth so don't log these attempts
             // Pattern from sabre/dav/lib/DAV/Auth/Backend/AbstractDigest.php
             if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false) {
-                error_log('user not authorized: Baikal DAV: '.$e->getMessage());
+                error_log('user not authorized: Baikal DAV: ' . $e->getMessage());
             }
         }
     }

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -191,6 +191,8 @@ class Server {
             if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false) {
                 error_log('user not authorized: Baikal DAV: ' . $e->getMessage());
             }
+        } else {
+            error_log($e);
         }
     }
 

--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -38,6 +38,7 @@ class Login extends \Flake\Core\Controller {
         $sMessage = "";
 
         if (self::isSubmitted() && !\BaikalAdmin\Core\Auth::isAuthenticated()) {
+            error_log('user not authorized: Baikal GUI');
             $sMessage = \Formal\Core\Message::error(
                 "The login/password you provided is invalid. Please retry.",
                 "Authentication error"

--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -38,6 +38,7 @@ class Login extends \Flake\Core\Controller {
         $sMessage = "";
 
         if (self::isSubmitted() && !\BaikalAdmin\Core\Auth::isAuthenticated()) {
+            // Log failed accesses, for further processing by other tools (fail2ban)
             error_log('user not authorized: Baikal GUI');
             $sMessage = \Formal\Core\Message::error(
                 "The login/password you provided is invalid. Please retry.",


### PR DESCRIPTION
Hi,

This PR logs failed accesses, for both DAV and admin console.
Goal is to process them with tools such as fail2ban, in order to ban these incoming IPs.

Error message follows the standard pattern proposed here : https://github.com/fail2ban/fail2ban/pull/1646
`user \S* ?(not found|not authorized|password mismatch|sent invalid token|misbehaved|tried to break-in)\b`

And these error messages directly go into the webserver log, which is generally already processed by such tools.

This then closes #726.

Many thanks 👍 

Ben