### PR TITLE
Bcrypt

### DIFF
--- a/Core/Frameworks/Baikal/Core/BcryptAuth.php
+++ b/Core/Frameworks/Baikal/Core/BcryptAuth.php
@@ -66,15 +66,15 @@ class BcryptAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
         $result = $stmt->fetchAll();
         if (!count($result)) return false;
 
-	if (substr($result[0]['digesta1'],0,4) == '$2y$') {
-		$check = password_verify($password, $result[0]['digesta1']);
-	} else {
-	        $hash = md5($username . ':' . $this->authRealm . ':' . $password);
-        	if ($result[0]['digesta1'] === $hash) {
-			$check = true;
-		}
-	}
-	if ($check == true) {
+        if (substr($result[0]['digesta1'],0,4) == '$2y$') {
+                $check = password_verify($password, $result[0]['digesta1']);
+        } else {
+                $hash = md5($username . ':' . $this->authRealm . ':' . $password);
+                if ($result[0]['digesta1'] === $hash) {
+                        $check = true;
+                }
+        }
+        if ($check == true) {
             $this->currentUser = $username;
             return true;
         }

--- a/Core/Frameworks/Baikal/Core/BcryptAuth.php
+++ b/Core/Frameworks/Baikal/Core/BcryptAuth.php
@@ -75,7 +75,6 @@ class BcryptAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
                 }
         }
         if ($check == true) {
-            // $this->currentUser = $username;
             return true;
         }
         return false;

--- a/Core/Frameworks/Baikal/Core/BcryptAuth.php
+++ b/Core/Frameworks/Baikal/Core/BcryptAuth.php
@@ -66,7 +66,7 @@ class BcryptAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
         $result = $stmt->fetchAll();
         if (!count($result)) return false;
 
-        if (substr($result[0]['digesta1'],0,4) == '$2y$') {
+        if (substr($result[0]['digesta1'], 0, 4) == '$2y$') {
                 $check = password_verify($password, $result[0]['digesta1']);
         } else {
                 $hash = md5($username . ':' . $this->authRealm . ':' . $password);

--- a/Core/Frameworks/Baikal/Core/BcryptAuth.php
+++ b/Core/Frameworks/Baikal/Core/BcryptAuth.php
@@ -75,7 +75,7 @@ class BcryptAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
                 }
         }
         if ($check == true) {
-            $this->currentUser = $username;
+            // $this->currentUser = $username;
             return true;
         }
         return false;

--- a/Core/Frameworks/Baikal/Core/BcryptAuth.php
+++ b/Core/Frameworks/Baikal/Core/BcryptAuth.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Baikal\Core;
+
+/**
+ * This is an authentication backend that uses a database to manage passwords.
+ *
+ * Format of the database tables must match to the one of \Sabre\DAV\Auth\Backend\PDO
+ *
+ * @copyright Copyright (C) 2013 Lukasz Janyst. All rights reserved.
+ * @author Lukasz Janyst <ljanyst@buggybrain.net>
+ * @license http://code.google.com/p/sabredav/wiki/License Modified BSD License
+ */
+class BcryptAuth extends \Sabre\DAV\Auth\Backend\AbstractBasic {
+
+    /**
+     * Reference to PDO connection
+     *
+     * @var PDO
+     */
+    protected $pdo;
+
+    /**
+     * PDO table name we'll be using
+     *
+     * @var string
+     */
+    protected $tableName;
+
+    /**
+     * Authentication realm
+     *
+     * @var string
+     */
+    protected $authRealm;
+
+    /**
+     * Creates the backend object.
+     *
+     * If the filename argument is passed in, it will parse out the specified file fist.
+     *
+     * @param PDO $pdo
+     * @param string $tableName The PDO table name to use
+     */
+    function __construct(\PDO $pdo, $authRealm, $tableName = 'users') {
+
+        $this->pdo = $pdo;
+        $this->tableName = $tableName;
+        $this->authRealm = $authRealm;
+    }
+
+    /**
+     * Validates a username and password
+     *
+     * This method should return true or false depending on if login
+     * succeeded.
+     *
+     * @param string $username
+     * @param string $password
+     * @return bool
+     */
+    function validateUserPass($username, $password) {
+
+        $stmt = $this->pdo->prepare('SELECT username, digesta1 FROM ' . $this->tableName . ' WHERE username = ?');
+        $stmt->execute([$username]);
+        $result = $stmt->fetchAll();
+        if (!count($result)) return false;
+
+	if (substr($result[0]['digesta1'],0,4) == '$2y$') {
+		$check = password_verify($password, $result[0]['digesta1']);
+	} else {
+	        $hash = md5($username . ':' . $this->authRealm . ':' . $password);
+        	if ($result[0]['digesta1'] === $hash) {
+			$check = true;
+		}
+	}
+	if ($check == true) {
+            $this->currentUser = $username;
+            return true;
+        }
+        return false;
+
+    }
+
+}

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -133,7 +133,7 @@ class Server {
 
         if ($this->authType === 'Basic') {
                 $authBackend = new \Baikal\Core\BcryptAuth($this->pdo, $this->authRealm);
-        } else { 
+        } else {
                 $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
                 $authBackend->setRealm($this->authRealm);
         }

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -132,11 +132,11 @@ class Server {
     protected function initServer() {
 
         if ($this->authType === 'Basic') {
-	    $authBackend = new \Baikal\Core\BcryptAuth($this->pdo, $this->authRealm);
+                $authBackend = new \Baikal\Core\BcryptAuth($this->pdo, $this->authRealm);
         } else { 
-            $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
-            $authBackend->setRealm($this->authRealm);
-	}
+                $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
+                $authBackend->setRealm($this->authRealm);
+        }
         $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($this->pdo);
 
         $nodes = [

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -132,11 +132,11 @@ class Server {
     protected function initServer() {
 
         if ($this->authType === 'Basic') {
-            $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
-        } else {
+	    $authBackend = new \Baikal\Core\BcryptAuth($this->pdo, $this->authRealm);
+        } else { 
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);
-        }
+	}
         $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($this->pdo);
 
         $nodes = [

--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -24,18 +24,20 @@
 #  This copyright notice MUST APPEAR in all copies of the script!
 #################################################################
 
-
 namespace Baikal\Core;
 
-class Tools {
-    static function &db() {
-        return $GLOBALS["pdo"];
+class Tools
+{
+    public static function &db()
+    {
+        return $GLOBALS['pdo'];
     }
 
-    static function assertEnvironmentIsOk() {
+    public static function assertEnvironmentIsOk()
+    {
         # Asserting Baikal Context
-        if (!defined("BAIKAL_CONTEXT") || BAIKAL_CONTEXT !== true) {
-            die("Bootstrap.php may not be included outside the Baikal context");
+        if (!defined('BAIKAL_CONTEXT') || BAIKAL_CONTEXT !== true) {
+            die('Bootstrap.php may not be included outside the Baikal context');
         }
 
         # Asserting PDO
@@ -50,21 +52,24 @@ class Tools {
         }
     }
 
-    static function configureEnvironment() {
+    public static function configureEnvironment()
+    {
         set_exception_handler('\Baikal\Core\Tools::handleException');
-        ini_set("error_reporting", E_ALL);
+        ini_set('error_reporting', E_ALL);
     }
 
-    static function handleException($exception) {
-        echo "<pre>" . $exception . "<pre>";
+    public static function handleException($exception)
+    {
+        echo '<pre>'.$exception.'<pre>';
     }
 
-    static function assertBaikalIsOk() {
+    public static function assertBaikalIsOk()
+    {
 
         # DB connexion has not been asserted earlier by Flake, to give us a chance to trigger the install tool
         # We assert it right now
-        if (!\Flake\Framework::isDBInitialized() && (!defined("BAIKAL_CONTEXT_INSTALL") || BAIKAL_CONTEXT_INSTALL === false)) {
-            throw new \Exception("<strong>Fatal error</strong>: no connection to a database is available.");
+        if (!\Flake\Framework::isDBInitialized() && (!defined('BAIKAL_CONTEXT_INSTALL') || BAIKAL_CONTEXT_INSTALL === false)) {
+            throw new \Exception('<strong>Fatal error</strong>: no connection to a database is available.');
         }
 
         # Asserting that the database is structurally complete
@@ -73,51 +78,52 @@ class Tools {
         #}
 
         # Asserting config file exists
-        if (!file_exists(PROJECT_PATH_SPECIFIC . "config.php")) {
-            throw new \Exception("Specific/config.php does not exist. Please use the Install tool to create it.");
+        if (!file_exists(PROJECT_PATH_SPECIFIC.'config.php')) {
+            throw new \Exception('Specific/config.php does not exist. Please use the Install tool to create it.');
         }
 
         # Asserting config file is readable
-        if (!is_readable(PROJECT_PATH_SPECIFIC . "config.php")) {
+        if (!is_readable(PROJECT_PATH_SPECIFIC.'config.php')) {
             throw new \Exception("Specific/config.php is not readable. Please give read permissions to httpd user on file 'Specific/config.php'.");
         }
 
         # Asserting config file is writable
-        if (!is_writable(PROJECT_PATH_SPECIFIC . "config.php")) {
+        if (!is_writable(PROJECT_PATH_SPECIFIC.'config.php')) {
             throw new \Exception("Specific/config.php is not writable. Please give write permissions to httpd user on file 'Specific/config.php'.");
         }
 
         # Asserting system config file exists
-        if (!file_exists(PROJECT_PATH_SPECIFIC . "config.system.php")) {
-            throw new \Exception("Specific/config.system.php does not exist. Please use the Install tool to create it.");
+        if (!file_exists(PROJECT_PATH_SPECIFIC.'config.system.php')) {
+            throw new \Exception('Specific/config.system.php does not exist. Please use the Install tool to create it.');
         }
 
         # Asserting system config file is readable
-        if (!is_readable(PROJECT_PATH_SPECIFIC . "config.system.php")) {
+        if (!is_readable(PROJECT_PATH_SPECIFIC.'config.system.php')) {
             throw new \Exception("Specific/config.system.php is not readable. Please give read permissions to httpd user on file 'Specific/config.system.php'.");
         }
 
         # Asserting system config file is writable
-        if (!is_writable(PROJECT_PATH_SPECIFIC . "config.system.php")) {
+        if (!is_writable(PROJECT_PATH_SPECIFIC.'config.system.php')) {
             throw new \Exception("Specific/config.system.php is not writable. Please give write permissions to httpd user on file 'Specific/config.system.php'.");
         }
     }
 
-    static function getRequiredTablesList() {
+    public static function getRequiredTablesList()
+    {
         return [
-            "addressbooks",
-            "calendarobjects",
-            "calendars",
-            "cards",
-            "groupmembers",
-            "locks",
-            "principals",
-            "users",
+            'addressbooks',
+            'calendarobjects',
+            'calendars',
+            'cards',
+            'groupmembers',
+            'locks',
+            'principals',
+            'users',
         ];
     }
 
-    static function isDBStructurallyComplete(\Flake\Core\Database $oDB) {
-
+    public static function isDBStructurallyComplete(\Flake\Core\Database $oDB)
+    {
         $aRequiredTables = self::getRequiredTablesList();
         $aPresentTables = $oDB->tables();
 
@@ -129,42 +135,47 @@ class Tools {
         return true;
     }
 
-    static function bashPrompt($prompt) {
+    public static function bashPrompt($prompt)
+    {
         echo $prompt;
         @flush();
         @ob_flush();
         $confirmation = @trim(fgets(STDIN));
+
         return $confirmation;
     }
 
-    static function bashPromptSilent($prompt = "Enter Password:") {
+    public static function bashPromptSilent($prompt = 'Enter Password:')
+    {
         $command = "/usr/bin/env bash -c 'echo OK'";
 
         if (rtrim(shell_exec($command)) !== 'OK') {
             trigger_error("Can't invoke bash");
+
             return;
         }
 
         $command = "/usr/bin/env bash -c 'read -s -p \""
-        . addslashes($prompt)
-        . "\" mypassword && echo \$mypassword'";
+        .addslashes($prompt)
+        ."\" mypassword && echo \$mypassword'";
 
         $password = rtrim(shell_exec($command));
         echo "\n";
+
         return $password;
     }
 
-    static function getCopyrightNotice($sLinePrefixChar = "#", $sLineSuffixChar = "", $sOpening = false, $sClosing = false) {
-
+    public static function getCopyrightNotice($sLinePrefixChar = '#', $sLineSuffixChar = '', $sOpening = false, $sClosing = false)
+    {
         if ($sOpening === false) {
-            $sOpening = str_repeat("#", 78);
+            $sOpening = str_repeat('#', 78);
         }
 
         if ($sClosing === false) {
-            $sClosing = str_repeat("#", 78);
+            $sClosing = str_repeat('#', 78);
         }
 
-        $iYear = date("Y");
+        $iYear = date('Y');
 
         $sCode = <<<CODE
 Copyright notice
@@ -190,27 +201,29 @@ GNU General Public License for more details.
 
 This copyright notice MUST APPEAR in all copies of the script!
 CODE;
-        $sCode = "\n" . trim($sCode) . "\n";
+        $sCode = "\n".trim($sCode)."\n";
         $aCode = explode("\n", $sCode);
         foreach (array_keys($aCode) as $iLineNum) {
-            $aCode[$iLineNum] = trim($sLinePrefixChar . "\t" . $aCode[$iLineNum]);
+            $aCode[$iLineNum] = trim($sLinePrefixChar."\t".$aCode[$iLineNum]);
         }
 
-        if (trim($sOpening) !== "") {
+        if (trim($sOpening) !== '') {
             array_unshift($aCode, $sOpening);
         }
 
-        if (trim($sClosing) !== "") {
+        if (trim($sClosing) !== '') {
             $aCode[] = $sClosing;
         }
 
         return implode("\n", $aCode);
     }
 
-    static function timezones() {
+    public static function timezones()
+    {
         $aZones = \DateTimeZone::listIdentifiers();
 
         reset($aZones);
+
         return $aZones;
     }
 }

--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -24,16 +24,17 @@
 #  This copyright notice MUST APPEAR in all copies of the script!
 #################################################################
 
+
 namespace Baikal\Core;
 
 class Tools
 {
-    public static function &db()
+    static function &db()
     {
         return $GLOBALS['pdo'];
     }
 
-    public static function assertEnvironmentIsOk()
+    static function assertEnvironmentIsOk()
     {
         # Asserting Baikal Context
         if (!defined('BAIKAL_CONTEXT') || BAIKAL_CONTEXT !== true) {
@@ -52,18 +53,18 @@ class Tools
         }
     }
 
-    public static function configureEnvironment()
+    static function configureEnvironment()
     {
         set_exception_handler('\Baikal\Core\Tools::handleException');
         ini_set('error_reporting', E_ALL);
     }
 
-    public static function handleException($exception)
+    static function handleException($exception)
     {
-        echo '<pre>'.$exception.'<pre>';
+        echo '<pre>' . $exception . '<pre>';
     }
 
-    public static function assertBaikalIsOk()
+    static function assertBaikalIsOk()
     {
 
         # DB connexion has not been asserted earlier by Flake, to give us a chance to trigger the install tool
@@ -78,37 +79,37 @@ class Tools
         #}
 
         # Asserting config file exists
-        if (!file_exists(PROJECT_PATH_SPECIFIC.'config.php')) {
+        if (!file_exists(PROJECT_PATH_SPECIFIC . 'config.php')) {
             throw new \Exception('Specific/config.php does not exist. Please use the Install tool to create it.');
         }
 
         # Asserting config file is readable
-        if (!is_readable(PROJECT_PATH_SPECIFIC.'config.php')) {
+        if (!is_readable(PROJECT_PATH_SPECIFIC . 'config.php')) {
             throw new \Exception("Specific/config.php is not readable. Please give read permissions to httpd user on file 'Specific/config.php'.");
         }
 
         # Asserting config file is writable
-        if (!is_writable(PROJECT_PATH_SPECIFIC.'config.php')) {
+        if (!is_writable(PROJECT_PATH_SPECIFIC . 'config.php')) {
             throw new \Exception("Specific/config.php is not writable. Please give write permissions to httpd user on file 'Specific/config.php'.");
         }
 
         # Asserting system config file exists
-        if (!file_exists(PROJECT_PATH_SPECIFIC.'config.system.php')) {
+        if (!file_exists(PROJECT_PATH_SPECIFIC . 'config.system.php')) {
             throw new \Exception('Specific/config.system.php does not exist. Please use the Install tool to create it.');
         }
 
         # Asserting system config file is readable
-        if (!is_readable(PROJECT_PATH_SPECIFIC.'config.system.php')) {
+        if (!is_readable(PROJECT_PATH_SPECIFIC . 'config.system.php')) {
             throw new \Exception("Specific/config.system.php is not readable. Please give read permissions to httpd user on file 'Specific/config.system.php'.");
         }
 
         # Asserting system config file is writable
-        if (!is_writable(PROJECT_PATH_SPECIFIC.'config.system.php')) {
+        if (!is_writable(PROJECT_PATH_SPECIFIC . 'config.system.php')) {
             throw new \Exception("Specific/config.system.php is not writable. Please give write permissions to httpd user on file 'Specific/config.system.php'.");
         }
     }
 
-    public static function getRequiredTablesList()
+    static function getRequiredTablesList()
     {
         return [
             'addressbooks',
@@ -122,7 +123,7 @@ class Tools
         ];
     }
 
-    public static function isDBStructurallyComplete(\Flake\Core\Database $oDB)
+    static function isDBStructurallyComplete(\Flake\Core\Database $oDB)
     {
         $aRequiredTables = self::getRequiredTablesList();
         $aPresentTables = $oDB->tables();
@@ -135,7 +136,7 @@ class Tools
         return true;
     }
 
-    public static function bashPrompt($prompt)
+    static function bashPrompt($prompt)
     {
         echo $prompt;
         @flush();
@@ -145,7 +146,7 @@ class Tools
         return $confirmation;
     }
 
-    public static function bashPromptSilent($prompt = 'Enter Password:')
+    static function bashPromptSilent($prompt = 'Enter Password:')
     {
         $command = "/usr/bin/env bash -c 'echo OK'";
 
@@ -156,8 +157,8 @@ class Tools
         }
 
         $command = "/usr/bin/env bash -c 'read -s -p \""
-        .addslashes($prompt)
-        ."\" mypassword && echo \$mypassword'";
+        . addslashes($prompt)
+        . "\" mypassword && echo \$mypassword'";
 
         $password = rtrim(shell_exec($command));
         echo "\n";
@@ -165,7 +166,7 @@ class Tools
         return $password;
     }
 
-    public static function getCopyrightNotice($sLinePrefixChar = '#', $sLineSuffixChar = '', $sOpening = false, $sClosing = false)
+    static function getCopyrightNotice($sLinePrefixChar = '#', $sLineSuffixChar = '', $sOpening = false, $sClosing = false)
     {
         if ($sOpening === false) {
             $sOpening = str_repeat('#', 78);
@@ -201,10 +202,10 @@ GNU General Public License for more details.
 
 This copyright notice MUST APPEAR in all copies of the script!
 CODE;
-        $sCode = "\n".trim($sCode)."\n";
+        $sCode = "\n" . trim($sCode) . "\n";
         $aCode = explode("\n", $sCode);
         foreach (array_keys($aCode) as $iLineNum) {
-            $aCode[$iLineNum] = trim($sLinePrefixChar."\t".$aCode[$iLineNum]);
+            $aCode[$iLineNum] = trim($sLinePrefixChar . "\t" . $aCode[$iLineNum]);
         }
 
         if (trim($sOpening) !== '') {
@@ -218,7 +219,7 @@ CODE;
         return implode("\n", $aCode);
     }
 
-    public static function timezones()
+    static function timezones()
     {
         $aZones = \DateTimeZone::listIdentifiers();
 

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -144,7 +144,7 @@ class Standard extends \Baikal\Model\Config {
             # Special handling for password and passwordconfirm
 
             if ($sProp === "BAIKAL_ADMIN_PASSWORDHASH" && $sValue !== "") {
-		if (BAIKAL_USER_AUTH_TYPE === "BCrypt") {
+		if ("BAIKAL_USER_AUTH_TYPE" === "BCrypt") {
 	                parent::set(
         	            "BAIKAL_ADMIN_PASSWORDHASH",
 			    password_hash($sValue,PASSWORD_BCRYPT)

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -101,13 +101,13 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "BAIKAL_DAV_AUTH_TYPE",
             "label"   => "WebDAV authentication type",
-            "options" => ["Basic","Digest"]
+            "options" => ["Basic", "Digest"]
         ]));
 
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "BAIKAL_USER_AUTH_TYPE",
             "label"   => "Password Storage Hash Type",
-            "options" => ["Bcrypt","MD5"],
+            "options" => ["Bcrypt", "MD5"],
             "help"    => "If set to BCrypt, WebDAV must be set to BASIC."
         ]));
 
@@ -146,7 +146,7 @@ class Standard extends \Baikal\Model\Config {
             if ($sProp === "BAIKAL_ADMIN_PASSWORDHASH" && $sValue !== "") {
                         parent::set(
                             "BAIKAL_ADMIN_PASSWORDHASH",
-                            password_hash($sValue,PASSWORD_BCRYPT)
+                            password_hash($sValue, PASSWORD_BCRYPT)
                         );
                   }
             return $this;

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -106,9 +106,9 @@ class Standard extends \Baikal\Model\Config {
 
 	$oMorpho->add(new \Formal\Element\Listbox([
 	    "prop"    => "BAIKAL_USER_AUTH_TYPE",
-	    "label"   => "Password Storage Engine",
+	    "label"   => "Password Storage Hash Type",
 	    "options" => ["Bcrypt","MD5"],
-	    "help"    => "If set to BCrypt, WebDAV must be set to BASIC.<br><strong>If you change this setting, you must change your password before you log out or you will be locked out!</strong>"
+	    "help"    => "If set to BCrypt, WebDAV must be set to BASIC."
 	]));
 
         $oMorpho->add(new \Formal\Element\Password([
@@ -144,18 +144,11 @@ class Standard extends \Baikal\Model\Config {
             # Special handling for password and passwordconfirm
 
             if ($sProp === "BAIKAL_ADMIN_PASSWORDHASH" && $sValue !== "") {
-		if (!defined("BAIKAL_USER_AUTH_TYPE") || BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
 	                parent::set(
         	            "BAIKAL_ADMIN_PASSWORDHASH",
 			    password_hash($sValue,PASSWORD_BCRYPT)
 	                );
-            	} else {
-			parent::set(
-	                    "BAIKAL_ADMIN_PASSWORDHASH",
-        	            \BaikalAdmin\Core\Auth::hashAdminPassword($sValue)
-	                );
 		  }
-              }
 	    return $this;
 	  }
 
@@ -213,7 +206,7 @@ define("BAIKAL_INVITE_FROM", "noreply@$_SERVER[SERVER_NAME]");
 define("BAIKAL_DAV_AUTH_TYPE", "Basic");
 
 
-# Baikal user authentication mechanism; default bcrypt
+# Baikal user password hash method; default bcrypt
 define("BAIKAL_USER_AUTH_TYPE", "Bcrypt");
 
 # Baïkal Web admin password hash; Set via Baïkal Web Admin

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -101,13 +101,13 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "BAIKAL_DAV_AUTH_TYPE",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic"]
+            "options" => ["Digest","Digest"]
         ]));
 
 	$oMorpho->add(new \Formal\Element\Listbox([
 	    "prop"    => "BAIKAL_USER_AUTH_TYPE",
 	    "label"   => "Password Storage Engine",
-	    "options" => ["MD5","BCrypt"],
+	    "options" => ["Bcrypt","MD5"],
 	    "help"    => "If set to BCrypt, WebDAV must be set to BASIC.<br><strong>If you change this setting, you must change your password before you log out or you will be locked out!</strong>"
 	]));
 
@@ -209,8 +209,8 @@ define("BAIKAL_CAL_ENABLED", TRUE);
 # CalDAV invite From: mail address (comment or leave blank to disable notifications)
 define("BAIKAL_INVITE_FROM", "noreply@$_SERVER[SERVER_NAME]");
 
-# WebDAV authentication type; default Digest
-define("BAIKAL_DAV_AUTH_TYPE", "Digest");
+# WebDAV authentication type; default Basic
+define("BAIKAL_DAV_AUTH_TYPE", "Basic");
 
 
 # Baikal user authentication mechanism; default bcrypt

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -144,7 +144,7 @@ class Standard extends \Baikal\Model\Config {
             # Special handling for password and passwordconfirm
 
             if ($sProp === "BAIKAL_ADMIN_PASSWORDHASH" && $sValue !== "") {
-		if ("BAIKAL_USER_AUTH_TYPE" === "BCrypt") {
+		if (!defined("BAIKAL_USER_AUTH_TYPE") || BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
 	                parent::set(
         	            "BAIKAL_ADMIN_PASSWORDHASH",
 			    password_hash($sValue,PASSWORD_BCRYPT)

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -48,7 +48,7 @@ class Standard extends \Baikal\Model\Config {
         ],
         "BAIKAL_DAV_AUTH_TYPE" => [
             "type"    => "string",
-            "comment" => "HTTP authentication type for WebDAV; default Digest"
+            "comment" => "HTTP authentication type for WebDAV; default Basic"
         ],
         "BAIKAL_USER_AUTH_TYPE" => [
         "type"    => "string",
@@ -101,7 +101,7 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "BAIKAL_DAV_AUTH_TYPE",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest","Digest"]
+            "options" => ["Basic","Digest"]
         ]));
 
 	$oMorpho->add(new \Formal\Element\Listbox([

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -67,7 +67,7 @@ class Standard extends \Baikal\Model\Config {
         "BAIKAL_CAL_ENABLED"        => true,
         "BAIKAL_INVITE_FROM"        => "",
         "BAIKAL_DAV_AUTH_TYPE"      => "Basic",
-	"BAIKAL_USER_AUTH_TYPE"     => "Bcrypt",
+        "BAIKAL_USER_AUTH_TYPE"     => "Bcrypt",
         "BAIKAL_ADMIN_PASSWORDHASH" => ""
     ];
 
@@ -104,12 +104,12 @@ class Standard extends \Baikal\Model\Config {
             "options" => ["Basic","Digest"]
         ]));
 
-	$oMorpho->add(new \Formal\Element\Listbox([
-	    "prop"    => "BAIKAL_USER_AUTH_TYPE",
-	    "label"   => "Password Storage Hash Type",
-	    "options" => ["Bcrypt","MD5"],
-	    "help"    => "If set to BCrypt, WebDAV must be set to BASIC."
-	]));
+        $oMorpho->add(new \Formal\Element\Listbox([
+            "prop"    => "BAIKAL_USER_AUTH_TYPE",
+            "label"   => "Password Storage Hash Type",
+            "options" => ["Bcrypt","MD5"],
+            "help"    => "If set to BCrypt, WebDAV must be set to BASIC."
+        ]));
 
         $oMorpho->add(new \Formal\Element\Password([
             "prop"  => "BAIKAL_ADMIN_PASSWORDHASH",
@@ -144,13 +144,13 @@ class Standard extends \Baikal\Model\Config {
             # Special handling for password and passwordconfirm
 
             if ($sProp === "BAIKAL_ADMIN_PASSWORDHASH" && $sValue !== "") {
-	                parent::set(
-        	            "BAIKAL_ADMIN_PASSWORDHASH",
-			    password_hash($sValue,PASSWORD_BCRYPT)
-	                );
-		  }
-	    return $this;
-	  }
+                        parent::set(
+                            "BAIKAL_ADMIN_PASSWORDHASH",
+                            password_hash($sValue,PASSWORD_BCRYPT)
+                        );
+                  }
+            return $this;
+          }
 
         parent::set($sProp, $sValue);
     }

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -107,7 +107,7 @@ class User extends \Flake\Core\Model\Db {
                 if (BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
                         parent::set(
                             "digesta1",
-                            password_hash($sPropValue,PASSWORD_BCRYPT)
+                            password_hash($sPropValue, PASSWORD_BCRYPT)
                         );
                 } else {
                         parent::set(

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -104,10 +104,17 @@ class User extends \Flake\Core\Model\Db {
             # Special handling for password and passwordconfirm
 
             if ($sPropName === "password" && $sPropValue !== "") {
-                parent::set(
-                    "digesta1",
-                    $this->getPasswordHashForPassword($sPropValue)
-                );
+		if (BAIKAL_USER_AUTH_TYPE === "BCrypt") {
+			parent::set(
+		            "digesta1",
+			    password_hash($sPropValue,PASSWORD_BCRYPT)
+	                );
+		} else {
+			parent::set(
+        	            "digesta1",
+                	    $this->getPasswordHashForPassword($sPropValue)
+			);
+		}
             }
 
             return $this;

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -104,7 +104,7 @@ class User extends \Flake\Core\Model\Db {
             # Special handling for password and passwordconfirm
 
             if ($sPropName === "password" && $sPropValue !== "") {
-		if (BAIKAL_USER_AUTH_TYPE === "BCrypt") {
+		if (BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
 			parent::set(
 		            "digesta1",
 			    password_hash($sPropValue,PASSWORD_BCRYPT)

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -104,17 +104,17 @@ class User extends \Flake\Core\Model\Db {
             # Special handling for password and passwordconfirm
 
             if ($sPropName === "password" && $sPropValue !== "") {
-		if (BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
-			parent::set(
-		            "digesta1",
-			    password_hash($sPropValue,PASSWORD_BCRYPT)
-	                );
-		} else {
-			parent::set(
-        	            "digesta1",
-                	    $this->getPasswordHashForPassword($sPropValue)
-			);
-		}
+                if (BAIKAL_USER_AUTH_TYPE === "Bcrypt") {
+                        parent::set(
+                            "digesta1",
+                            password_hash($sPropValue,PASSWORD_BCRYPT)
+                        );
+                } else {
+                        parent::set(
+                            "digesta1",
+                            $this->getPasswordHashForPassword($sPropValue)
+                        );
+                }
             }
 
             return $this;

--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -45,9 +45,18 @@ class Auth {
         $sUser = \Flake\Util\Tools::POST("login");
         $sPass = \Flake\Util\Tools::POST("password");
 
-        $sPassHash = self::hashAdminPassword($sPass);
+	if (substr(BAIKAL_ADMIN_PASSWORDHASH,0,4) == "$2y$") {
+	        $sPassHash = password_verify($sPass, BAIKAL_ADMIN_PASSWORDHASH);
+	} else {
+		$sPassHash = self::hashAdminPassword($sPass);
+		if ($sPassHash === BAIKAL_ADMIN_PASSWORDHASH) {
+			$sPassHash = true;
+		} else {
+			$sPassHash = false;
+		}
+	}
 
-        if ($sUser === "admin" && $sPassHash === BAIKAL_ADMIN_PASSWORDHASH) {
+        if ($sUser === "admin" && $sPassHash == true) {
             $_SESSION["baikaladminauth"] = md5(BAIKAL_ADMIN_PASSWORDHASH);
             return true;
         }
@@ -66,7 +75,7 @@ class Auth {
         } else {
             $sAuthRealm = "BaikalDAV";    # Fallback to default value; useful when initializing App, as all constants are not set yet
         }
-
+	
         return md5('admin:' . $sAuthRealm . ':' . $sPassword);
     }
 

--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -45,16 +45,16 @@ class Auth {
         $sUser = \Flake\Util\Tools::POST("login");
         $sPass = \Flake\Util\Tools::POST("password");
 
-	if (substr(BAIKAL_ADMIN_PASSWORDHASH,0,4) == "$2y$") {
-	        $sPassHash = password_verify($sPass, BAIKAL_ADMIN_PASSWORDHASH);
-	} else {
-		$sPassHash = self::hashAdminPassword($sPass);
-		if ($sPassHash === BAIKAL_ADMIN_PASSWORDHASH) {
-			$sPassHash = true;
-		} else {
-			$sPassHash = false;
-		}
-	}
+    if (substr(BAIKAL_ADMIN_PASSWORDHASH, 0, 4) == "$2y$") {
+            $sPassHash = password_verify($sPass, BAIKAL_ADMIN_PASSWORDHASH);
+    } else {
+        $sPassHash = self::hashAdminPassword($sPass);
+        if ($sPassHash === BAIKAL_ADMIN_PASSWORDHASH) {
+            $sPassHash = true;
+        } else {
+            $sPassHash = false;
+        }
+    }
 
         if ($sUser === "admin" && $sPassHash == true) {
             $_SESSION["baikaladminauth"] = md5(BAIKAL_ADMIN_PASSWORDHASH);
@@ -75,7 +75,7 @@ class Auth {
         } else {
             $sAuthRealm = "BaikalDAV";    # Fallback to default value; useful when initializing App, as all constants are not set yet
         }
-	
+    
         return md5('admin:' . $sAuthRealm . ':' . $sPassword);
     }
 


### PR DESCRIPTION
This is my first pull request!

I have modified the code to allow for bcrypt based password hashing. In order to allow current users to continue connecting to the server, the authentication mechanism looks at the hash to see if it starts with $2y$ and if it does, it uses password_verify. If it does not, then it uses the existing auth mechanisms.

In order to keep digest method, I added a drop down on the settings page that allows the user to choose between basic and bcrypt authentication, along with a note that states if the setting is changed, the password must be changed.

Passwords will be unaffected by default. If set to use bcrypt, passwords will only be changed the next time they are changed. Passwords will authenticate no matter which hash they are using.

This will close #514 

Anyway, I have no idea how I'm supposed to end this or even if I'm rambling at this point. Thanks for the opportunity to help!