### PR TITLE
Set timezone when creating calendar

### DIFF
--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -39,7 +39,7 @@ class Calendar extends \Flake\Core\Model\Db {
         "description"   => "",
         "calendarorder" => 0,
         "calendarcolor" => "",
-        "timezone"      => "",
+        "timezone"      => PROJECT_TIMEZONE,
         "calendarid"    => 0
     ];
     protected $oCalendar; # Baikal\Model\Calendar\Calendar


### PR DESCRIPTION
When the timezone in the database is an empty string, this can lead
to problems with some clients.

Closes #862