### PR TITLE
Add a calendar events retention parameter

### DIFF
--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -218,8 +218,8 @@ class Calendar extends \Flake\Core\Model\Db {
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
-            "prop"  => "retention",
-            "label" => "Retention",
+            "prop"       => "retention",
+            "label"      => "Retention",
             "validation" => "positivenumber",
             "popover"    => [
                 "title"   => "Retention",

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -40,7 +40,8 @@ class Calendar extends \Flake\Core\Model\Db {
         "calendarorder" => 0,
         "calendarcolor" => "",
         "timezone"      => "",
-        "calendarid"    => 0
+        "calendarid"    => 0,
+        "retention"     => 0
     ];
     protected $oCalendar; # Baikal\Model\Calendar\Calendar
 
@@ -216,6 +217,15 @@ class Calendar extends \Flake\Core\Model\Db {
             "help"  => "If checked, notes will be enabled on this calendar.",
         ]));
 
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"  => "retention",
+            "label" => "Retention",
+            "validation" => "positivenumber",
+            "popover"    => [
+                "title"   => "Retention",
+                "content" => "Number of days to keep passed events (0 to prevent deletion)."
+            ]
+        ]));
 
         if ($this->floating()) {
             $oMorpho->element("uri")->setOption(

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -515,10 +515,20 @@ SQL
             $this->aSuccess[] = 'Migrated calendars table';
         }
 
+        if (version_compare($sVersionFrom, '0.6.2', '<')) {
+            if (!defined("PROJECT_DB_MYSQL") || PROJECT_DB_MYSQL === false) {
+                $pdo->exec("ALTER TABLE calendarinstances ADD retention integer DEFAULT '0' NOT NULL");
+                $this->aSuccess[] = 'Updated calendarinstances table';
+            } else { // mysql
+                $pdo->exec("ALTER TABLE calendarinstances ADD retention INTEGER UNSIGNED NOT NULL DEFAULT '0'");
+                $this->aSuccess[] = 'Updated calendarinstances table';
+            }
+        }
 
         $this->updateConfiguredVersion($sVersionTo);
         return true;
     }
+
 
     protected function updateConfiguredVersion($sVersionTo) {
 

--- a/Core/Frameworks/Formal/Form.php
+++ b/Core/Frameworks/Formal/Form.php
@@ -316,6 +316,14 @@ class Form {
         return true;
     }
 
+    function validatePositivenumber($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+        if (!preg_match("/^[0-9]+$/", $sValue)) {
+            return "<strong>" . $oElement->option("label") . "</strong> should be a positive number.";
+        }
+
+        return true;
+    }
+
     function validateColor($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
         if (!empty($sValue) && !preg_match("/^#[a-fA-F0-9]{6}([a-fA-F0-9]{2})?$/", $sValue)) {
             return "<strong>" . $oElement->option("label") . "</strong> is not a valid color with format '#RRGGBB' or '#RRGGBBAA' in hexadecimal values.";

--- a/Core/Resources/Db/MySQL/db.sql
+++ b/Core/Resources/Db/MySQL/db.sql
@@ -63,6 +63,7 @@ CREATE TABLE calendarinstances (
     share_href VARBINARY(100),
     share_displayname VARCHAR(100),
     share_invitestatus TINYINT(1) NOT NULL DEFAULT '2',
+    retention INTEGER UNSIGNED NOT NULL DEFAULT '0',
     UNIQUE(principaluri, uri),
     UNIQUE(calendarid, principaluri),
     UNIQUE(calendarid, share_href)

--- a/Core/Resources/Db/SQLite/db.sql
+++ b/Core/Resources/Db/SQLite/db.sql
@@ -61,6 +61,7 @@ CREATE TABLE calendarinstances (
     share_href text,
     share_displayname text,
     share_invitestatus integer DEFAULT '2',
+    retention integer DEFAULT '0' NOT NULL,
     UNIQUE (principaluri, uri),
     UNIQUE (calendarid, principaluri),
     UNIQUE (calendarid, share_href)


### PR DESCRIPTION
Hi,

This PR adds a per-calendar retention option.
It then helps issue #727.

Admin then has to schedule following requests to purge old entries :

SQLITE :
```
DELETE FROM calendarobjects,calendarinstances
WHERE calendarobjects.calendarid=calendarinstances.calendarid
AND retention>0
AND lastoccurence<((SELECT strftime("%s","now"))-(retention*86400));
```

MYSQL :
```
DELETE FROM calendarobjects,calendarinstances
WHERE calendarobjects.calendarid=calendarinstances.calendarid
AND retention>0
AND lastoccurence<((SELECT UNIX_TIMESTAMP())-(retention*86400));
```

I did not found a proper way to schedule, or at least trigger, these SQL requests from Baïkal itself.
Feel free if you have the method !

Thank you 👍 