### PR TITLE
Use default Fail2Ban auth messages

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -185,7 +185,7 @@ class Server {
     }
 
     /**
-     * Log failed accesses, for further processing by other tools (fail2ban)
+     * Log failed accesses, matching the default fail2ban nginx/apache auth rules
      *
      * @return void
      */
@@ -193,9 +193,12 @@ class Server {
         if ($e instanceof \Sabre\DAV\Exception\NotAuthenticated) {
             // Applications may make their first call without auth so don't log these attempts
             // Pattern from sabre/dav/lib/DAV/Auth/Backend/AbstractDigest.php
-            if (strpos($e->getMessage(), "No 'Authorization: Digest' header found.") === false
-                && strpos($e->getMessage(), "No 'Authorization: Basic' header found.") === false) {
-                error_log('user not authorized: Baikal DAV: ' . $e->getMessage());
+            if (!preg_match("/No 'Authorization: (Basic|Digest)' header found./", $e->getMessage())) {
+                if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
+                    error_log('user "(name stripped-out)" was not found in "Baikal DAV"', 4);
+                } else {
+                    error_log('user "(name stripped-out)" authentication failure for "Baikal DAV"', 4);
+                }
             }
         } else {
             error_log($e);

--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -37,9 +37,15 @@ class Login extends \Flake\Core\Controller {
         $sSubmittedFlagName = "auth";
         $sMessage = "";
 
+        $sLogin = htmlspecialchars(\Flake\Util\Tools::POST("login"));
+
         if (self::isSubmitted() && !\BaikalAdmin\Core\Auth::isAuthenticated()) {
-            // Log failed accesses, for further processing by other tools (fail2ban)
-            error_log('user not authorized: Baikal GUI');
+            // Log failed accesses, matching the default fail2ban nginx/apache auth rules
+            if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
+                error_log('user "' . $sLogin . '" was not found in "Baikal GUI"', 4);
+            } else {
+                error_log('user "' . $sLogin . '" authentication failure for "Baikal GUI"', 4);
+            }
             $sMessage = \Formal\Core\Message::error(
                 "The login/password you provided is invalid. Please retry.",
                 "Authentication error"
@@ -52,7 +58,6 @@ class Login extends \Flake\Core\Controller {
             );
         }
 
-        $sLogin = htmlspecialchars(\Flake\Util\Tools::POST("login"));
         $sPassword = htmlspecialchars(\Flake\Util\Tools::POST("password"));
 
         if (trim($sLogin) === "") {


### PR DESCRIPTION
Hi,

This PR modifies authentication failed message patterns, taking the Fail2Ban default ones, so that no additional Fail2Ban configuration is required.
It then makes things easier.

Many thanks 👍 

Ben