### PR TITLE
Fix 'Undefined variable: ' reported by phpstan

### DIFF
--- a/Core/Frameworks/Flake/Core/Requester.php
+++ b/Core/Frameworks/Flake/Core/Requester.php
@@ -39,7 +39,7 @@ abstract class Requester extends \Flake\Core\FLObject {
 
     function limit($iStart, $iNumber = false) {
         if ($iNumber !== false) {
-            return $this->setLimitStart($iStart)->setLimitNumber($iLimitNumber);
+            return $this->setLimitStart($iStart)->setLimitNumber($iNumber);
         }
 
         return $this->setLimitStart($iStart);


### PR DESCRIPTION
I am attempting to run `phpstan` at level 0. It reports lots of things that are not so important/essential.
But it does report:
```
 ------ ---------------------------------------------------------------------- 
  Line   Core/Frameworks/Flake/Core/Requester.php                              
 ------ ---------------------------------------------------------------------- 
  34     Access to an undefined property Flake\Core\Requester::$sModelClass.   
  39     Call to an undefined method Flake\Core\Requester::addClauseEquals().  
  47     Undefined variable: $iLimitNumber                                     
  55     Access to an undefined property Flake\Core\Requester::$sOrderField.   
  56     Access to an undefined property                                       
         Flake\Core\Requester::$sOrderDirection.                               
  63     Access to an undefined property Flake\Core\Requester::$iLimitStart.   
  70     Access to an undefined property Flake\Core\Requester::$iLimitNumber.  
 ------ ---------------------------------------------------------------------- 
```
The `Access to an undefined property` messages are "just" that the properties are not declared in the class code. There are lots of those reported, which could be fixed-up some time.

But the `Undefined variable: $iLimitNumber` is an error in the var name. That should be fixed.

Note: I don;t see anything that uses `Requestyer->limit()` - so IMO this is unused code and so that could be why nobody reported a problem with this.