### PR TITLE
Add PHP 7.4 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 dist: trusty
 php:
-  - 7
+  - 7.0
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
~Start by doing the minimum - drop PHP 7.0 and run the existing lint an old code-style checks with PHP 7.4~

See discussion below. Now this PR does even less change - just adds PHP 7.4 to the test matrix.

Issue #876 