### PR TITLE
Add event count column in calendar overview

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
@@ -68,6 +68,7 @@ class Calendars extends \Flake\Core\Controller {
                 "linkdelete"  => $this->linkDelete($calendar),
                 "icon"        => $calendar->icon(),
                 "label"       => $calendar->label(),
+                "events"      => $calendar->getEventsBaseRequester()->count(),
                 "description" => $calendar->get("description"),
             ];
         }

--- a/Core/Frameworks/BaikalAdmin/Resources/Templates/User/Calendars.html
+++ b/Core/Frameworks/BaikalAdmin/Resources/Templates/User/Calendars.html
@@ -10,6 +10,7 @@
 	<thead>
 		<tr>
 			<th>Display name</th>
+			<th>Events</th>
 			<th>Description</th>
 			<th class="no-border-left"></th>
 		</tr>
@@ -18,6 +19,7 @@
 		{% for calendar in calendars %}
 		<tr>
 			<td class="col-displayname"><i class="{{ calendar.icon }}"></i>{{ calendar.label|escape }}</td>
+			<td class="col-events">{{ calendar.events|escape }}</td>
 			<td class="col-description">{{ calendar.description|escape }}</td>
 			<td class="col-actions no-border-left">
 				<p class="pull-right">


### PR DESCRIPTION
I like the minimal *Number of events* badge in the dashboard but missed a more exact overview about events per calendar.

![baikal](https://user-images.githubusercontent.com/24757415/75786386-7c7f0280-5d65-11ea-852a-52a2cad42cef.png)

This PR adds an *Events* column in the calendar overview.
