### PR TITLE
Exclude Chain.php from phpstan due to signature of push()

### DIFF
--- a/Core/Frameworks/Flake/Core/Datastructure/Chain.php
+++ b/Core/Frameworks/Flake/Core/Datastructure/Chain.php
@@ -28,6 +28,13 @@
 namespace Flake\Core\Datastructure;
 
 class Chain extends \SplDoublyLinkedList {
+    /*
+     * Note: SplDoublyLinkedList::push expects mixed $value
+     * https://www.php.net/manual/en/spldoublylinkedlist.push.php
+     * In this implementation it has been restricted to Chainable.
+     * phpstan complains about that. So analaysis of this file has been
+     * disabled in the excludes_analyse section of phpstan.neon
+     */
     function push(\Flake\Core\Datastructure\Chainable $value) {
         $value->chain($this, $this->count());
         parent::push($value);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ parameters:
   level: 0
   excludes_analyse:
     - Core/Frameworks/BaikalAdmin/Resources/GlyphiconsPro/generate-sprite.php
+    - Core/Frameworks/Flake/Core/Datastructure/Chain.php
     - Core/Resources/Web/BaikalAdmin/GlyphiconsPro/generate-sprite.php
     - html/res/core/BaikalAdmin/GlyphiconsPro/generate-sprite.php
   ignoreErrors:


### PR DESCRIPTION
New releases of `phpstan` have happened in the last 2 days. `phpstan` analyzes more stuff now.
https://github.com/phpstan/phpstan/releases/tag/0.12.27
https://github.com/phpstan/phpstan/releases/tag/0.12.26

It tells:
```
$ composer require --dev phpstan/phpstan:^0.12
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing phpstan/phpstan (0.12.27): Downloading (100%)         
Writing lock file
Generating autoload files
$ php vendor/bin/phpstan.phar analyse Core html
Note: Using configuration file /home/phil/git/sabre-io/Baikal/phpstan.neon.
 118/118 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   Core/Frameworks/Flake/Core/Datastructure/Chain.php                                                                              
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  31     Parameter #1 $value (Flake\Core\Datastructure\Chainable) of method Flake\Core\Datastructure\Chain::push() is not contravariant  
         with parameter #1 $value (mixed) of method SplDoublyLinkedList::push().                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
                                                                                                                        
 [ERROR] Found 1 error                                                                                                  
```

https://www.php.net/manual/en/spldoublylinkedlist.push.php does indeed have signature `mixed $value` and class `Chain` that extends it is restricting the parameter.

If I try to ignore the error by putting
```
	/* @phpstan-ignore-next-line */
```
In `Chain.php`  then `phpstan` still complains:
```
$ php vendor/bin/phpstan.phar analyse Core html
Note: Using configuration file /home/phil/git/sabre-io/Baikal/phpstan.neon.
 118/118 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   Core/Frameworks/Flake/Core/Datastructure/Chain.php                                                                              
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  32     No error to ignore is reported on line 32.                                                                                      
  32     Parameter #1 $value (Flake\Core\Datastructure\Chainable) of method Flake\Core\Datastructure\Chain::push() is not contravariant  
         with parameter #1 $value (mixed) of method SplDoublyLinkedList::push().                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 2 errors                                                                                                 
```

If I try to ignore the error by adding to the `ignoreErrors` section of `phpstan.neon`:
```
    -
      message: '#Parameter .+ of method .+ is not contravariant with .+#'
      path: Core/Frameworks/Flake/Core/Datastructure/Chain.php
```

Then I get:
```
$ php vendor/bin/phpstan.phar analyse Core html
Note: Using configuration file /home/phil/git/sabre-io/Baikal/phpstan.neon.
 118/118 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  Line   Core/Frameworks/Flake/Core/Datastructure/Chain.php                                                                              
 ------ -------------------------------------------------------------------------------------------------------------------------------- 
  31     Parameter #1 $value (Flake\Core\Datastructure\Chainable) of method Flake\Core\Datastructure\Chain::push() is not contravariant  
         with parameter #1 $value (mixed) of method SplDoublyLinkedList::push().                                                         
 ------ -------------------------------------------------------------------------------------------------------------------------------- 

 -- --------------------------------------------------------------------------------------------------------------------------------- 
     Error                                                                                                                            
 -- --------------------------------------------------------------------------------------------------------------------------------- 
     Error message "Parameter #1 $value (Flake\Core\Datastructure\Chainable) of method Flake\Core\Datastructure\Chain::push() is not  
     contravariant with parameter #1 $value (mixed) of method SplDoublyLinkedList::push()." cannot be ignored, use excludes_analyse   
     instead.                                                                                                                         
 -- --------------------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 2 errors                                                                                                 

```

And so I have to put `Chain.php` in the `excludes_analyse` section of `phpstan.neon`