### PR TITLE
Fixed user deletion

### DIFF
--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -257,7 +257,8 @@ class Calendar extends \Flake\Core\Model\Db {
     }
 
     function destroy() {
-        if (!$this->hasInstances()) {
+        $hasInstances = $this->hasInstances();
+        if (!$hasInstances) {
             $oEvents = $this->getEventsBaseRequester()->execute();
             foreach ($oEvents as $event) {
                 $event->destroy();
@@ -265,6 +266,8 @@ class Calendar extends \Flake\Core\Model\Db {
         }
 
         parent::destroy();
-        $this->oCalendar->destroy();
+        if (!$hasInstances) {
+            $this->oCalendar->destroy();
+        }
     }
 }

--- a/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
@@ -40,7 +40,7 @@ class Calendar extends \Flake\Core\Model\Db {
         $rSql = $GLOBALS["DB"]->exec_SELECTquery(
             "count(*)",
             "calendarinstances",
-            "calendarid" . "='" . $this->aData["calendarid"] . "'"
+            "calendarid" . "='" . $this->aData["id"] . "'"
         );
 
         if (($aRs = $rSql->fetch()) === false) {
@@ -53,8 +53,9 @@ class Calendar extends \Flake\Core\Model\Db {
     }
 
     function destroy() {
-        if (!$this->hasInstances()) {
-            parent::destroy();
+        if ($this->hasInstances()) {
+            throw new \Exception("Trying to destroy a calendar with instances");
         }
+        parent::destroy();
     }
 }

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -181,7 +181,9 @@ class User extends \Flake\Core\Model\Db {
         # TODO: delete all related resources (principals, calendars, calendar events, contact books and contacts)
 
         # Destroying identity principal
-        $this->oIdentityPrincipal->destroy();
+        if ($this->oIdentityPrincipal != null) {
+            $this->oIdentityPrincipal->destroy();
+        }
 
         $oCalendars = $this->getCalendarsBaseRequester()->execute();
         foreach ($oCalendars as $calendar) {

--- a/Core/Frameworks/BaikalAdmin/Controller/Users.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Users.php
@@ -165,6 +165,7 @@ class Users extends \Flake\Core\Controller {
                 $oUser->destroy();
             } catch (\Exception $e) {
                 # user is already deleted; silently discarding
+                error_log($e);
             }
 
             # Redirecting to admin home


### PR DESCRIPTION
We should rename `Model\Calendar` to `Model\CalendarInstance` to prevent confusion with `Model\Calendar\Calendar`...

Closes #936