### PR TITLE
Option to choose Sabre/DAV Apache Auth backend

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -133,6 +133,8 @@ class Server {
 
         if ($this->authType === 'Basic') {
             $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
+        } elseif ($this->authType === 'Apache') {
+            $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -103,7 +103,7 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "dav_auth_type",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic"]
+            "options" => ["Digest", "Basic", "Apache"]
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([

--- a/Core/Frameworks/Flake/Controller/Cli.php
+++ b/Core/Frameworks/Flake/Controller/Cli.php
@@ -48,8 +48,6 @@ class Cli extends \Flake\Core\Render\Container {
         }
     }
 
-    /**************************************************************************/
-
     public $sLog = "";
 
     function sys_init() {

--- a/Core/Frameworks/Flake/Core/Collection.php
+++ b/Core/Frameworks/Flake/Core/Collection.php
@@ -115,6 +115,7 @@ class Collection extends \Flake\Core\FLObject implements \Iterator {
         }
 
         $var = null;    # two lines instead of one
+
         return $var;    # as PHP needs a variable to return by ref
     }
 
@@ -148,6 +149,7 @@ class Collection extends \Flake\Core\FLObject implements \Iterator {
     # This abstraction is useful because of CollectionTyped
     protected function newCollectionLikeThisOne() {
         $oCollection = new \Flake\Core\Collection();    # two lines instead of one
+
         return $oCollection;                            # as PHP needs a variable to return by ref
     }
 

--- a/Core/Frameworks/Flake/Util/Router.php
+++ b/Core/Frameworks/Flake/Util/Router.php
@@ -112,6 +112,7 @@ abstract class Router extends \Flake\Core\FLObject {
         $sCurrentRoute = $GLOBALS["ROUTER"]::getCurrentRoute();
 
         array_unshift($aParams, $sCurrentRoute);    # Injecting route as first param
+
         return call_user_func_array($GLOBALS["ROUTER"] . "::buildRoute", $aParams);
     }
 

--- a/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
+++ b/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
@@ -51,6 +51,7 @@ class QuestionMarkRewrite extends \Flake\Util\Router {
         }
 
         $aBestMatches = array_pop($aMatches);    // obtains the deepest matching route (higher number of slashes)
+
         return array_shift($aBestMatches);        // first route amongst best matches
     }
 


### PR DESCRIPTION
This enables to use any auth mechanism supported by apache to be used
for DAV authentication with Baikal, for example SPNEGO/GSSAPI/Kerberos.

- Apache must be configured to require the wanted authentication on the
  Baikal Location.

- On successful authentication, it passes the name of the authenticated
  user via server variable to the Sabre/DAV auth backend.

- If the authentication is performed for a user not known to Baikal, it
will issue a corresponding error.