### PR TITLE
Sabre/DAV IMAP authentication.

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -76,6 +76,13 @@ class Server {
     protected $pdo;
 
     /**
+     * IMAP mailbox.
+     *
+     * @var string
+     */
+    protected $mailbox;
+
+    /**
      * baseUri for the sabre/dav server.
      *
      * @var string
@@ -99,13 +106,14 @@ class Server {
      * @param PDO $pdo
      * @param string $baseUri
      */
-    function __construct($enableCalDAV, $enableCardDAV, $authType, $authRealm, PDO $pdo, $baseUri) {
+    function __construct($enableCalDAV, $enableCardDAV, $authType, $authRealm, PDO $pdo, $baseUri, $mailbox) {
         $this->enableCalDAV = $enableCalDAV;
         $this->enableCardDAV = $enableCardDAV;
         $this->authType = $authType;
         $this->authRealm = $authRealm;
         $this->pdo = $pdo;
         $this->baseUri = $baseUri;
+        $this->mailbox = $mailbox;
 
         $this->initServer();
     }
@@ -135,6 +143,8 @@ class Server {
             $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
         } elseif ($this->authType === 'Apache') {
             $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
+        } elseif ($this->authType === 'IMAP') {
+            $authBackend = new \Sabre\DAV\Auth\Backend\IMAP($this->mailbox);
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -76,11 +76,11 @@ class Server {
     protected $pdo;
 
     /**
-     * IMAP mailbox.
+     * IMAP server.
      *
      * @var string
      */
-    protected $mailbox;
+    protected $dav_auth_imap_server;
 
     /**
      * baseUri for the sabre/dav server.
@@ -106,14 +106,14 @@ class Server {
      * @param PDO $pdo
      * @param string $baseUri
      */
-    function __construct($enableCalDAV, $enableCardDAV, $authType, $authRealm, PDO $pdo, $baseUri, $mailbox) {
+    function __construct($enableCalDAV, $enableCardDAV, $authType, $authRealm, PDO $pdo, $baseUri, $dav_auth_imap_server) {
         $this->enableCalDAV = $enableCalDAV;
         $this->enableCardDAV = $enableCardDAV;
         $this->authType = $authType;
         $this->authRealm = $authRealm;
         $this->pdo = $pdo;
         $this->baseUri = $baseUri;
-        $this->mailbox = $mailbox;
+        $this->dav_auth_imap_server = $dav_auth_imap_server;
 
         $this->initServer();
     }
@@ -144,7 +144,7 @@ class Server {
         } elseif ($this->authType === 'Apache') {
             $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
         } elseif ($this->authType === 'IMAP') {
-            $authBackend = new \Sabre\DAV\Auth\Backend\IMAP($this->mailbox);
+            $authBackend = new \Sabre\DAV\Auth\Backend\IMAP($this->dav_auth_imap_server);
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -42,7 +42,8 @@ class Standard extends \Baikal\Model\Config {
         // While not editable as will change admin & any existing user passwords,
         // could be set to different value when migrating from legacy config
         "auth_realm"            => "BaikalDAV",
-        "base_uri"              => ""
+        "base_uri"              => "",
+        "mailbox"               => ""
     ];
 
     function __construct() {
@@ -79,7 +80,7 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "dav_auth_type",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic", "Apache"]
+            "options" => ["Digest", "Basic", "Apache", "IMAP"]
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([
@@ -91,6 +92,12 @@ class Standard extends \Baikal\Model\Config {
             "prop"       => "admin_passwordhash_confirm",
             "label"      => "Admin password, confirmation",
             "validation" => "sameas:admin_passwordhash",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop"  => "mailbox",
+            "label" => "IMAP mailbox",
+            "help"  => "IMAP server in the form {host[:port][/flag1/flag2...]}"
         ]));
 
         try {

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -43,7 +43,7 @@ class Standard extends \Baikal\Model\Config {
         // could be set to different value when migrating from legacy config
         "auth_realm"            => "BaikalDAV",
         "base_uri"              => "",
-        "mailbox"               => ""
+        "dav_auth_imap_server"  => ""
     ];
 
     function __construct() {
@@ -95,8 +95,8 @@ class Standard extends \Baikal\Model\Config {
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
-            "prop"  => "mailbox",
-            "label" => "IMAP mailbox",
+            "prop"  => "dav_auth_imap_server",
+            "label" => "IMAP server",
             "help"  => "IMAP server in the form {host[:port][/flag1/flag2...]}"
         ]));
 

--- a/html/cal.php
+++ b/html/cal.php
@@ -69,6 +69,7 @@ $server = new \Baikal\Core\Server(
     $config['system']["dav_auth_type"],
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
-    PROJECT_BASEURI . 'cal.php/'
+    PROJECT_BASEURI . 'cal.php/',
+    $config['system']["mailbox"]
 );
 $server->start();

--- a/html/cal.php
+++ b/html/cal.php
@@ -70,6 +70,6 @@ $server = new \Baikal\Core\Server(
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
     PROJECT_BASEURI . 'cal.php/',
-    $config['system']["mailbox"]
+    $config['system']["dav_auth_imap_server"]
 );
 $server->start();

--- a/html/card.php
+++ b/html/card.php
@@ -69,6 +69,7 @@ $server = new \Baikal\Core\Server(
     $config['system']["dav_auth_type"],
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
-    PROJECT_BASEURI . 'card.php/'
+    PROJECT_BASEURI . 'card.php/',
+    $config['system']["mailbox"]
 );
 $server->start();

--- a/html/card.php
+++ b/html/card.php
@@ -70,6 +70,6 @@ $server = new \Baikal\Core\Server(
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
     PROJECT_BASEURI . 'card.php/',
-    $config['system']["mailbox"]
+    $config['system']["dav_auth_imap_server"]
 );
 $server->start();

--- a/html/dav.php
+++ b/html/dav.php
@@ -64,6 +64,7 @@ $server = new \Baikal\Core\Server(
     $config['system']["dav_auth_type"],
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
-    PROJECT_BASEURI . 'dav.php/'
+    PROJECT_BASEURI . 'dav.php/',
+    $config['system']["mailbox"]
 );
 $server->start();

--- a/html/dav.php
+++ b/html/dav.php
@@ -65,6 +65,6 @@ $server = new \Baikal\Core\Server(
     $config['system']["auth_realm"],
     $GLOBALS['DB']->getPDO(),
     PROJECT_BASEURI . 'dav.php/',
-    $config['system']["mailbox"]
+    $config['system']["dav_auth_imap_server"]
 );
 $server->start();


### PR DESCRIPTION
Hi,

I added IMAP authentication option to Baïkal using Sabre/DAV IMAP implementation.
I've been using a patch for IMAP however I read it was better to use sabre/dav implementation and it is working very well. It needs only one parameter and is very versatile.

Hope this helps.

Closes #848