### PR TITLE
Fixes for migrating from legacy version

### DIFF
--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -65,6 +65,8 @@ class Standard extends \Baikal\Model\Config {
         "cal_enabled"        => true,
         "dav_auth_type"      => "Digest",
         "admin_passwordhash" => "",
+        // While not editable as will change admin & any existing user passwords,
+        // could be set to different value when migrating from legacy config
         "auth_realm"         => "BaikalDAV",
         "base_uri"           => ""
     ];
@@ -146,7 +148,7 @@ class Standard extends \Baikal\Model\Config {
             if ($sProp === "admin_passwordhash" && $sValue !== "") {
                 parent::set(
                     "admin_passwordhash",
-                    \BaikalAdmin\Core\Auth::hashAdminPassword($sValue)
+                    \BaikalAdmin\Core\Auth::hashAdminPassword($sValue, $this->aData["auth_realm"])
                 );
             }
 

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -215,12 +215,8 @@ class Database extends \Flake\Core\Controller {
         if ($oForm->submitted()) {
             $bMySQL = (intval($oForm->postValue("mysql")) === 1);
         } else {
-            try {
-                $configSystem = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
-            } catch (\Exception $e) {
-                error_log('Error reading baikal.yaml file : ' . $e->getMessage());
-            }
-            $bMySQL = $configSystem['database']['mysql'] ?? true;
+            // oMorpho won't have the values from the model set on it yet
+            $bMySQL = $this->oModel->get("mysql");
         }
 
         if ($bMySQL === true) {

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -46,12 +46,6 @@ class Database extends \Flake\Core\Controller {
             $this->oModel->set('mysql_username', PROJECT_DB_MYSQL_USERNAME);
             $this->oModel->set('mysql_password', PROJECT_DB_MYSQL_PASSWORD);
             $this->oModel->set('encryption_key', BAIKAL_ENCRYPTION_KEY);
-
-            if (defined("BAIKAL_CONFIGURED_VERSION")) {
-                $oStandardConfig = new \Baikal\Model\Config\Standard();
-                $oStandardConfig->set("configured_version", BAIKAL_CONFIGURED_VERSION);
-                $oStandardConfig->persist();
-            }
         }
 
         $this->oForm = $this->oModel->formForThisModelInstance([
@@ -68,6 +62,18 @@ class Database extends \Flake\Core\Controller {
                     @unlink(PROJECT_PATH_SPECIFIC . "config.system.php");
                 }
                 touch(PROJECT_PATH_SPECIFIC . '/INSTALL_DISABLED');
+
+                if (defined("BAIKAL_CONFIGURED_VERSION")) {
+                    $oStandardConfig = new \Baikal\Model\Config\Standard();
+                    $oStandardConfig->set("configured_version", BAIKAL_CONFIGURED_VERSION);
+                    $oStandardConfig->persist();
+
+                    # We've just rolled back the configured version, so reload so that we get to the
+                    # version upgrade page rather than the database is configured message in render below
+                    $sLink = PROJECT_URI . "admin/install/?/database";
+                    \Flake\Util\Tools::redirect($sLink);
+                    exit(0);
+                }
             }
         }
     }

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -27,8 +27,6 @@
 
 namespace BaikalAdmin\Controller\Install;
 
-use Symfony\Component\Yaml\Yaml;
-
 class Database extends \Flake\Core\Controller {
     protected $aMessages = [];
     protected $oModel;

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
@@ -55,6 +55,10 @@ class Initialize extends \Flake\Core\Controller {
             $this->oModel->set('invite_from', defined("BAIKAL_INVITE_FROM") ? BAIKAL_INVITE_FROM : "");
             $this->oModel->set('dav_auth_type', BAIKAL_DAV_AUTH_TYPE);
         }
+        if (file_exists(PROJECT_PATH_SPECIFIC . "config.system.php")) {
+            require_once PROJECT_PATH_SPECIFIC . "config.system.php";
+            $this->oModel->set('auth_realm', BAIKAL_AUTH_REALM);
+        }
 
         $this->oForm = $this->oModel->formForThisModelInstance([
             "close" => false

--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -52,6 +52,7 @@ class Auth {
             $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
         } catch (\Exception $e) {
             error_log('Error reading baikal.yaml file : ' . $e->getMessage());
+
             return false;
         }
         $sPassHash = self::hashAdminPassword($sPass, $config['system']['auth_realm']);

--- a/Core/Frameworks/BaikalAdmin/Core/Auth.php
+++ b/Core/Frameworks/BaikalAdmin/Core/Auth.php
@@ -48,12 +48,13 @@ class Auth {
         $sUser = \Flake\Util\Tools::POST("login");
         $sPass = \Flake\Util\Tools::POST("password");
 
-        $sPassHash = self::hashAdminPassword($sPass);
         try {
             $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
         } catch (\Exception $e) {
             error_log('Error reading baikal.yaml file : ' . $e->getMessage());
+            return false;
         }
+        $sPassHash = self::hashAdminPassword($sPass, $config['system']['auth_realm']);
         if ($sUser === "admin" && $sPassHash === $config['system']['admin_passwordhash']) {
             $_SESSION["baikaladminauth"] = md5($config['system']['admin_passwordhash']);
 
@@ -67,16 +68,7 @@ class Auth {
         unset($_SESSION["baikaladminauth"]);
     }
 
-    static function hashAdminPassword($sPassword) {
-        try {
-            $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
-        } catch (\Exception $e) {
-            error_log('Error reading baikal.yaml file : ' . $e->getMessage());
-        }
-
-        # Fallback to default value; useful when initializing App, as all constants are not set yet
-        $sAuthRealm = $config['system']['auth_realm'] ?? "BaikalDAV";
-
+    static function hashAdminPassword($sPassword, $sAuthRealm) {
         return hash('sha256', 'admin:' . $sAuthRealm . ':' . $sPassword);
     }
 }


### PR DESCRIPTION
Tested with a MySQL DB dump & config of a 0.3.5 instance.

I'm able to:
* Go through the upgrade wizard successfully
* Toggle between MySQL/sqlite & enter incorrect values on the database settings form, and don't get moved onto until I correct the values
* Login to the admin UI & interact with dav.php as a normal user after migration, having migrated with a non-standard auth realm

Things still not migrated:
* `BAIKAL_ENCRYPTION_KEY` - this doesn't appear to be read anywhere, so I didn't bother fixing the migration for that. If you desire I can update this PR to either migrate it (if there's some use I haven't spotted) or stop storing it altogether.
* `BAIKAL_CARD_BASEURI`, `BAIKAL_CAL_BASEURI` & `BAIKAL_DAV_BASEURI` - the use of these from card.php, cal.php & dav.php respectively appears to have been removed. In my legacy instance all 3 of these were set to `PROJECT_BASEURI`. This allowed my nginx config to rewrite any request that wasn't to `/admin` or `/res` to `/dav.php`, so that `dav.php` didn't show up in the URL. I haven't figured out how to replicate this in 0.7.1 but I feel that is a separate problem to what I'm solve with this PR.

Fixes #942 #946 I think