### PR TITLE
Add link to calendar URI in user overview

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
@@ -63,6 +63,7 @@ class Calendars extends \Flake\Core\Controller {
             $aCalendars[] = [
                 "linkedit"    => $this->linkEdit($calendar),
                 "linkdelete"  => $this->linkDelete($calendar),
+                "davuri"      => $this->getDavUri($calendar),
                 "icon"        => $calendar->icon(),
                 "label"       => $calendar->label(),
                 "instanced"   => $calendar->hasInstances(),
@@ -268,5 +269,16 @@ class Calendars extends \Flake\Core\Controller {
         return self::buildRoute([
             "user" => $this->currentUserId(),
         ]);
+    }
+
+    /**
+     * Generate a link to the CalDAV/CardDAV URI of the calendar.
+     *
+     * @param \Baikal\Model\Calendar $calendar
+     *
+     * @return string Calender DAV URI
+     */
+    protected function getDavUri(\Baikal\Model\Calendar $calendar) {
+        return PROJECT_BASEURI . 'dav.php/calendars/' . $this->oUser->get('username') . '/' . $calendar->get('uri') . '/';
     }
 }

--- a/Core/Frameworks/BaikalAdmin/Resources/Templates/Page/style.css
+++ b/Core/Frameworks/BaikalAdmin/Resources/Templates/Page/style.css
@@ -75,8 +75,8 @@ table.addressbooks .col-actions { width: 25%;}
 
 /* Calendars */
 table.calendars .col-displayname { width: 20%;}
-table.calendars .col-description { width: 55%;}
-table.calendars .col-actions { width: 25%;}
+table.calendars .col-description { width: 40%;}
+table.calendars .col-actions { width: 40%;}
 
 /* Users */
 table.users .col-id { width: 2%;}

--- a/Core/Frameworks/BaikalAdmin/Resources/Templates/User/Calendars.html
+++ b/Core/Frameworks/BaikalAdmin/Resources/Templates/User/Calendars.html
@@ -23,6 +23,7 @@
 			<td class="col-description">{{ calendar.description|escape }}</td>
 			<td class="col-actions no-border-left">
 				<p class="pull-right">
+					<nobr><a class="btn" href="{{ calendar.davuri }}"><i class="{{ calendaricon }}"></i> Calendar URI</a></nobr>
 					<nobr><a class="btn btn-primary" href="{{ calendar.linkedit }}"><i class="icon-edit icon-white"></i> Edit</a></nobr>
 					<nobr><a class="btn btn-danger" href="{{ calendar.linkdelete }}"><i class="icon-remove icon-white"></i> Delete</a></nobr>
 				</p>


### PR DESCRIPTION
Add a link to the URI of a calendar to easen sharing calendars
with the calendar user any avoid writing these links manually.

Closes #974