### PR TITLE
Add failed_access_message option

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -186,7 +186,7 @@ class Server {
     }
 
     /**
-     * Log failed accesses, matching the default fail2ban nginx/apache auth rules.
+     * Log failed accesses, for further processing by tools like Fail2Ban.
      *
      * @return void
      */
@@ -195,10 +195,10 @@ class Server {
             // Applications may make their first call without auth so don't log these attempts
             // Pattern from sabre/dav/lib/DAV/Auth/Backend/AbstractDigest.php
             if (!preg_match("/No 'Authorization: (Basic|Digest)' header found./", $e->getMessage())) {
-                if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
-                    error_log('user "(name stripped-out)" was not found in "Baikal DAV"', 4);
-                } else {
-                    error_log('user "(name stripped-out)" authentication failure for "Baikal DAV"', 4);
+                $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
+                if (isset($config['system']["failed_access_message"]) && $config['system']["failed_access_message"] !== "") {
+                    $log_msg = str_replace("%u", "(name stripped-out)", $config['system']["failed_access_message"]);
+                    error_log($log_msg, 4);
                 }
             }
         } else {

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -32,16 +32,17 @@ use Symfony\Component\Yaml\Yaml;
 class Standard extends \Baikal\Model\Config {
     # Default values
     protected $aData = [
-        "configured_version" => BAIKAL_VERSION,
-        "timezone"           => "Europe/Paris",
-        "card_enabled"       => true,
-        "cal_enabled"        => true,
-        "dav_auth_type"      => "Digest",
-        "admin_passwordhash" => "",
+        "configured_version"    => BAIKAL_VERSION,
+        "timezone"              => "Europe/Paris",
+        "card_enabled"          => true,
+        "cal_enabled"           => true,
+        "dav_auth_type"         => "Digest",
+        "admin_passwordhash"    => "",
+        "failed_access_message" => "user %u authentication failure for Baikal",
         // While not editable as will change admin & any existing user passwords,
         // could be set to different value when migrating from legacy config
-        "auth_realm"         => "BaikalDAV",
-        "base_uri"           => ""
+        "auth_realm"            => "BaikalDAV",
+        "base_uri"              => ""
     ];
 
     function __construct() {

--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -27,6 +27,8 @@
 
 namespace BaikalAdmin\Controller;
 
+use Symfony\Component\Yaml\Yaml;
+
 class Login extends \Flake\Core\Controller {
     function execute() {
     }
@@ -39,11 +41,11 @@ class Login extends \Flake\Core\Controller {
         $sLogin = htmlspecialchars(\Flake\Util\Tools::POST("login"));
 
         if (self::isSubmitted() && !\BaikalAdmin\Core\Auth::isAuthenticated()) {
-            // Log failed accesses, matching the default fail2ban nginx/apache auth rules
-            if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
-                error_log('user "' . $sLogin . '" was not found in "Baikal GUI"', 4);
-            } else {
-                error_log('user "' . $sLogin . '" authentication failure for "Baikal GUI"', 4);
+            // Log failed accesses, for further processing by tools like Fail2Ban
+            $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
+            if (isset($config['system']["failed_access_message"]) && $config['system']["failed_access_message"] !== "") {
+                $log_msg = str_replace("%u", $sLogin, $config['system']["failed_access_message"]);
+                error_log($log_msg, 4);
             }
             $sMessage = \Formal\Core\Message::error(
                 "The login/password you provided is invalid. Please retry.",

--- a/config/baikal.yaml.dist
+++ b/config/baikal.yaml.dist
@@ -6,6 +6,7 @@ system:
     invite_from: 'noreply@localhost'
     dav_auth_type: 'Digest'
     admin_passwordhash: 5fe794627e1f841f8debba065e2c807a
+    failed_access_message: 'user %u authentication failure for Baikal'
     auth_realm: BaikalDAV
     base_uri: ''
 database:


### PR DESCRIPTION
Hi,

This PR adds a new `failed_access_message` option.
It allows to tune (or disable if empty) the failed accesses log messages.
The option value can contain a `%u` parameter which will be replaced with the login user identifier.

This PR then improves the logging feature, being now able to match any existing Fail2Ban(-like) configuration.

Thank you 👍