### PR TITLE
Use minimum version 2.16.7 of php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/yaml"  : "^3.4"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.16.1"
+        "friendsofphp/php-cs-fixer": "~2.16.7"
     },
     "replace" : {
         "jeromeschneider/baikal" : "self.version"


### PR DESCRIPTION
For some unknown reason, using php-cs-fixer 2.16.1 on PHP 7.1 or PHP 7.4 in Travis results in fails like:
https://travis-ci.org/github/sabre-io/Baikal/jobs/740100183
```
$ if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi
In ToolInfo.php line 50:
  Undefined index: name 
The command "if [ $RUN_PHPSTAN == "FALSE" ]; then php vendor/bin/php-cs-fixer fix --dry-run --diff; fi" exited with 1.
```
That happens for the pipelines that have `--prefer-lowest` - which causes the lowest version of all PHP dependencies to be used.

It passes with PHP 7.2 and 7.3

The only obvious thing that I see in the Travis logs is that for PHP 7.1 and 7.4 the PHP versions are old patch versions. But for PHP 7.2 and 7.3 the PHP patch version provided is up-to-date (built in early October).

There is no real reason to need to use old versions of dev tools like php-cs-fixer. So I have bump the min version from 2.16.1 to 2.16.7 (the current version). That makes CI green, which is "a good thing"