### PR TITLE
Add authtype "Callback"

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -135,6 +135,10 @@ class Server {
             $authBackend = new \Baikal\Core\PDOBasicAuth($this->pdo, $this->authRealm);
         } elseif ($this->authType === 'Apache') {
             $authBackend = new \Sabre\DAV\Auth\Backend\Apache();
+        } elseif ($this->authType === 'Callback') {
+            $authBackend = new \Sabre\DAV\Auth\Backend\BasicCallBack(function ($username, $password) use (&$config) {
+                return call_user_func($config['system']['dav_auth_callback'], $username, $password);
+            });
         } else {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -41,7 +41,8 @@ class Standard extends \Baikal\Model\Config {
         // While not editable as will change admin & any existing user passwords,
         // could be set to different value when migrating from legacy config
         "auth_realm"         => "BaikalDAV",
-        "base_uri"           => ""
+        "base_uri"           => "",
+        "dav_auth_callback"  => ""
     ];
 
     function __construct() {
@@ -78,7 +79,7 @@ class Standard extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "dav_auth_type",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic", "Apache"]
+            "options" => ["Digest", "Basic", "Apache", "Callback"]
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([


### PR DESCRIPTION
This allows to programmatically add other auth types (such as IMAP) without adding support in Baikal directly. As this is not intended for regular users I've deliberately not added the callback to the admin configuration model.

e.g. we use something like this to authenticate against IMAP:
* add namespace `Local` to composer.json -> autoload -> psr-0: `"Local" : ""`
* create Local\Auth.php:
```php
declare(strict_types=1);

namespace Local;

class Auth {
  static public function validateUserPass($username, $password)
  {
    return self::imap_check('localhost:143}/notls', $username, $password);
  }

  /* copy from Sabre\DAV\Auth\Backend\IMAP */
  static private function imap_check($mailbox, $username, $password)
  {
    $success = false;

    try {
      $imap = imap_open($mailbox, $username, $password, OP_HALFOPEN | OP_READONLY, 1);
      if ($imap) {
          $success = true;
      }
    } catch (\ErrorException $e) {
      error_log($e->getMessage());
    }

    $errors = imap_errors();
    if ($errors) {
      foreach ($errors as $error) {
          error_log($error);
      }
    }

    if (isset($imap) && $imap) {
      imap_close($imap);
    }

    return $success;
  }
}
```
 * add callback to `config/baikal.yaml`: `dav_auth_callback: 'Local\Auth::validateUserPass'`