### PR TITLE
PHP 8.0

### DIFF
--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -35,23 +35,23 @@ class Tools {
     static function assertEnvironmentIsOk() {
         # Asserting Baikal Context
         if (!defined("BAIKAL_CONTEXT") || BAIKAL_CONTEXT !== true) {
-            die("Bootstrap.php may not be included outside the Baikal context");
+            exit("Bootstrap.php may not be included outside the Baikal context");
         }
 
         # Asserting PDO
         if (!defined('PDO::ATTR_DRIVER_NAME')) {
-            die('Baikal Fatal Error: PDO is unavailable. It\'s required by Baikal.');
+            exit('Baikal Fatal Error: PDO is unavailable. It\'s required by Baikal.');
         }
 
         # Asserting PDO::SQLite or PDO::MySQL
         $aPDODrivers = \PDO::getAvailableDrivers();
         if (!in_array('sqlite', $aPDODrivers, true) && !in_array('mysql', $aPDODrivers, true)) {
-            die('<strong>Baikal Fatal Error</strong>: Both <strong>PDO::sqlite</strong> and <strong>PDO::mysql</strong> are unavailable. One of them at least is required by Baikal.');
+            exit('<strong>Baikal Fatal Error</strong>: Both <strong>PDO::sqlite</strong> and <strong>PDO::mysql</strong> are unavailable. One of them at least is required by Baikal.');
         }
 
         # Assert that the temp folder is writable
         if (!\is_writable(\sys_get_temp_dir())) {
-            die('<strong>Baikal Fatal Error</strong>: The system temp directory is not writable.');
+            exit('<strong>Baikal Fatal Error</strong>: The system temp directory is not writable.');
         }
     }
 

--- a/Core/Frameworks/Baikal/WWWRoot/index.php
+++ b/Core/Frameworks/Baikal/WWWRoot/index.php
@@ -40,7 +40,7 @@ if (file_exists(getcwd() . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
@@ -39,7 +39,7 @@ class Initialize extends \Flake\Core\Controller {
             $message = "<h1>Error - Insufficient  permissions on the configuration folders</h1><p>";
             $message .= "<p>In order to work properly, Baïkal needs to have write permissions in the <strong>Specific/</strong> and <strong>config/</strong> folder.</p>";
 
-            die($message);
+            exit($message);
         }
 
         $this->createHtaccessFilesIfNeeded();

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -41,7 +41,7 @@ if (file_exists(dirname(getcwd()) . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -48,7 +48,7 @@ if (file_exists(dirname(dirname(getcwd())) . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 
 require PROJECT_PATH_ROOT . "vendor/autoload.php";
@@ -92,7 +92,7 @@ if (!$config || !isset($config['system']["configured_version"])) {
         $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Install\Database());
     } else {
         echo "Installation was already completed. Please head to the admin interface to modify any settings.\n";
-        die();
+        exit();
     }
 }
 

--- a/Core/Frameworks/Flake/Controller/Cli.php
+++ b/Core/Frameworks/Flake/Controller/Cli.php
@@ -81,7 +81,7 @@ class Cli extends \Flake\Core\Render\Container {
 
     function syntaxError() {
         $sStr = $this->rawLine("Syntax error.\nUsage: " . $this->getSyntax());
-        die("\n\n" . $sStr . "\n\n");
+        exit("\n\n" . $sStr . "\n\n");
     }
 
     function log($sStr) {

--- a/Core/Frameworks/Flake/Controller/Page.php
+++ b/Core/Frameworks/Flake/Controller/Page.php
@@ -115,7 +115,7 @@ class Page extends \Flake\Core\Render\Container {
             if (!file_exists($sCompiledPath)) {
                 @mkdir($sCompiledPath);
                 if (!file_exists($sCompiledPath)) {
-                    die("Page: Cannot create " . $sCompiledPath);
+                    exit("Page: Cannot create " . $sCompiledPath);
                 }
             }
 

--- a/Core/Frameworks/Flake/Core/Collection.php
+++ b/Core/Frameworks/Flake/Core/Collection.php
@@ -64,12 +64,6 @@ class Collection extends \Flake\Core\FLObject implements \Iterator {
         return $oRes;
     }
 
-    function &each() {
-        list($key, $val) = each($this->aCollection);
-
-        return $val;
-    }
-
     function reset() {
         reset($this->aCollection);
     }

--- a/Core/Frameworks/Flake/Core/Database.php
+++ b/Core/Frameworks/Flake/Core/Database.php
@@ -37,7 +37,7 @@ abstract class Database extends \Flake\Core\FLObject {
 
     protected function messageAndDie($sMessage) {
         $sError = "<h2>" . get_class($this) . ": " . $sMessage . "</h2>";
-        die($sError);
+        exit($sError);
     }
 
     function exec_INSERTquery($table, $fields_values, $no_quote_fields = false) {
@@ -102,7 +102,7 @@ abstract class Database extends \Flake\Core\FLObject {
                 return $query;
             }
         } else {
-            die('<strong>Fatal Error:</strong> "Where" clause argument for UPDATE query was not a string in $this->UPDATEquery() !');
+            exit('<strong>Fatal Error:</strong> "Where" clause argument for UPDATE query was not a string in $this->UPDATEquery() !');
         }
     }
 
@@ -124,7 +124,7 @@ abstract class Database extends \Flake\Core\FLObject {
 
             return $query;
         } else {
-            die('<strong>Fatal Error:</strong> "Where" clause argument for DELETE query was not a string in $this->DELETEquery() !');
+            exit('<strong>Fatal Error:</strong> "Where" clause argument for DELETE query was not a string in $this->DELETEquery() !');
         }
     }
 

--- a/Core/Frameworks/Flake/Core/Datastructure/Chainable.php
+++ b/Core/Frameworks/Flake/Core/Datastructure/Chainable.php
@@ -35,5 +35,5 @@ interface Chainable extends \ArrayAccess, \Iterator, \Countable {
 
     function &last();
 
-    function chain(\Flake\Core\Datastructure\Chain $chain, $key);
+    function chain(Chain $chain, $key);
 }

--- a/Core/Frameworks/Flake/Core/Route.php
+++ b/Core/Frameworks/Flake/Core/Route.php
@@ -27,9 +27,11 @@
 
 namespace Flake\Core;
 
+use Flake\Core\Render\Container;
+
 abstract class Route extends \Flake\Core\FLObject {
     # should be abstract, but is not, due to PHP strict standard
-    static function layout(\Flake\Core\Render\Container &$oRenderContainer) {
+    static function layout(Container &$oRenderContainer) {
     }
 
     static function parametersMap() {

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -95,7 +95,7 @@ class Framework extends \Flake\Core\Framework {
     static function bootstrap() {
         # Asserting PHP 5.5.0+
         if (version_compare(PHP_VERSION, '5.5.0', '<')) {
-            die('Flake Fatal Error: Flake requires PHP 5.5.0+ to run properly. Your version is: ' . PHP_VERSION . '.');
+            exit('Flake Fatal Error: Flake requires PHP 5.5.0+ to run properly. Your version is: ' . PHP_VERSION . '.');
         }
 
         # Define safehash salt
@@ -272,12 +272,12 @@ class Framework extends \Flake\Core\Framework {
 
         # Asserting DB file is writable
         if (file_exists($config['database']['sqlite_file']) && !is_writable($config['database']['sqlite_file'])) {
-            die("<h3>DB file is not writable. Please give write permissions on file '<span style='font-family: monospace; background: yellow;'>" . $config['database']['sqlite_file'] . "</span>'</h3>");
+            exit("<h3>DB file is not writable. Please give write permissions on file '<span style='font-family: monospace; background: yellow;'>" . $config['database']['sqlite_file'] . "</span>'</h3>");
         }
 
         # Asserting DB directory is writable
         if (!is_writable(dirname($config['database']['sqlite_file']))) {
-            die("<h3>The <em>FOLDER</em> containing the DB file is not writable, and it has to.<br />Please give write permissions on folder '<span style='font-family: monospace; background: yellow;'>" . dirname($config['database']['sqlite_file']) . "</span>'</h3>");
+            exit("<h3>The <em>FOLDER</em> containing the DB file is not writable, and it has to.<br />Please give write permissions on folder '<span style='font-family: monospace; background: yellow;'>" . dirname($config['database']['sqlite_file']) . "</span>'</h3>");
         }
 
         if (file_exists($config['database']['sqlite_file']) && is_readable($config['database']['sqlite_file']) && !isset($GLOBALS["DB"])) {
@@ -291,19 +291,19 @@ class Framework extends \Flake\Core\Framework {
 
     protected static function initDbMysql(array $config) {
         if (!$config['database']['mysql_host']) {
-            die("<h3>The constant PROJECT_DB_MYSQL_HOST, containing the MySQL host name, is not set.<br />You should set it in config/baikal.yaml</h3>");
+            exit("<h3>The constant PROJECT_DB_MYSQL_HOST, containing the MySQL host name, is not set.<br />You should set it in config/baikal.yaml</h3>");
         }
 
         if (!$config['database']['mysql_dbname']) {
-            die("<h3>The constant PROJECT_DB_MYSQL_DBNAME, containing the MySQL database name, is not set.<br />You should set it in config/baikal.yaml</h3>");
+            exit("<h3>The constant PROJECT_DB_MYSQL_DBNAME, containing the MySQL database name, is not set.<br />You should set it in config/baikal.yaml</h3>");
         }
 
         if (!$config['database']['mysql_username']) {
-            die("<h3>The constant PROJECT_DB_MYSQL_USERNAME, containing the MySQL database username, is not set.<br />You should set it in config/baikal.yaml</h3>");
+            exit("<h3>The constant PROJECT_DB_MYSQL_USERNAME, containing the MySQL database username, is not set.<br />You should set it in config/baikal.yaml</h3>");
         }
 
         if (!$config['database']['mysql_password']) {
-            die("<h3>The constant PROJECT_DB_MYSQL_PASSWORD, containing the MySQL database password, is not set.<br />You should set it in config/baikal.yaml</h3>");
+            exit("<h3>The constant PROJECT_DB_MYSQL_PASSWORD, containing the MySQL database password, is not set.<br />You should set it in config/baikal.yaml</h3>");
         }
 
         try {
@@ -317,7 +317,7 @@ class Framework extends \Flake\Core\Framework {
             # We now setup t6he connexion to use UTF8
             $GLOBALS["DB"]->query("SET NAMES UTF8");
         } catch (\Exception $e) {
-            die("<h3>Baïkal was not able to establish a connexion to the configured MySQL database (as configured in config/baikal.yaml).</h3>");
+            exit("<h3>Baïkal was not able to establish a connexion to the configured MySQL database (as configured in config/baikal.yaml).</h3>");
         }
 
         return true;

--- a/Core/Frameworks/Flake/Util/Tools.php
+++ b/Core/Frameworks/Flake/Util/Tools.php
@@ -397,7 +397,7 @@ TEST;
     static function HTTPStatus($iCode, $sMessage) {
         header("HTTP/1.1 404 Not Found");
         header("Status: 404 Not Found");
-        die("<h1>HTTP Status " . $iCode . " : " . $sMessage . "</h1>");
+        exit("<h1>HTTP Status " . $iCode . " : " . $sMessage . "</h1>");
     }
 
     static function number2Rank($a) {

--- a/Core/Frameworks/Formal/Form.php
+++ b/Core/Frameworks/Formal/Form.php
@@ -27,6 +27,8 @@
 
 namespace Formal;
 
+use Formal\Form\Morphology;
+
 class Form {
     protected $sModelClass = "";
     protected $aOptions = [
@@ -233,7 +235,7 @@ class Form {
     }
 
     # public, as it may be called from a hook
-    function declareError(\Formal\Element $oElement, $sMessage = "") {
+    function declareError(Element $oElement, $sMessage = "") {
         $this->aErrors[] = [
             "element" => $oElement,
             "message" => $sMessage,
@@ -254,7 +256,7 @@ class Form {
         return false;
     }
 
-    function validateRequired($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+    function validateRequired($sValue, Morphology $oMorpho, Element $oElement) {
         if (trim($sValue) !== "") {
             return true;
         }
@@ -262,7 +264,7 @@ class Form {
         return "<strong>" . $oElement->option("label") . "</strong> is required.";
     }
 
-    function validateEmail($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+    function validateEmail($sValue, Morphology $oMorpho, Element $oElement) {
         if (\Flake\Util\Tools::validEmail($sValue)) {
             return true;
         }
@@ -270,7 +272,7 @@ class Form {
         return "<strong>" . $oElement->option("label") . "</strong> should be an email.";
     }
 
-    function validateSameas($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement, $sReferencePropName) {
+    function validateSameas($sValue, Morphology $oMorpho, Element $oElement, $sReferencePropName) {
         $sReferenceValue = $oMorpho->element($sReferencePropName)->value();
         if ($sValue === $sReferenceValue) {
             return true;
@@ -279,7 +281,7 @@ class Form {
         return "<strong>" . $oElement->option("label") . "</strong> does not match " . $oMorpho->element($sReferencePropName)->option("label") . ".";
     }
 
-    function validateUnique($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+    function validateUnique($sValue, Morphology $oMorpho, Element $oElement) {
         $oModelInstance = $this->modelInstance();
 
         $oRequest = $oModelInstance->getBaseRequester()->addClauseEquals(
@@ -306,7 +308,7 @@ class Form {
         return true;
     }
 
-    function validateTokenid($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+    function validateTokenid($sValue, Morphology $oMorpho, Element $oElement) {
         if (!preg_match("/^[a-z0-9\-_]+$/", $sValue)) {
             return "<strong>" . $oElement->option("label") . "</strong> is not valid. Allowed characters are digits, lowercase letters, the dash and underscore symbol.";
         }
@@ -314,7 +316,7 @@ class Form {
         return true;
     }
 
-    function validateColor($sValue, \Formal\Form\Morphology $oMorpho, \Formal\Element $oElement) {
+    function validateColor($sValue, Morphology $oMorpho, Element $oElement) {
         if (!empty($sValue) && !preg_match("/^#[a-fA-F0-9]{6}([a-fA-F0-9]{2})?$/", $sValue)) {
             return "<strong>" . $oElement->option("label") . "</strong> is not a valid color with format '#RRGGBB' or '#RRGGBBAA' in hexadecimal values.";
         }

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php"           : "^7.1",
+        "php"           : "^7.1 || ^8.0",
         "sabre/dav"     : "~4.1.2",
         "twig/twig"     : "~2.12.5",
         "symfony/yaml"  : "^3.4"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "~2.16.7"
+        "friendsofphp/php-cs-fixer": "^2.17"
     },
     "replace" : {
         "jeromeschneider/baikal" : "self.version"

--- a/html/cal.php
+++ b/html/cal.php
@@ -42,7 +42,7 @@ if (file_exists(getcwd() . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
@@ -56,7 +56,7 @@ require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 try {
     $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
 } catch (\Exception $e) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
 }
 
 if (!isset($config['system']["cal_enabled"]) || $config['system']["cal_enabled"] !== true) {

--- a/html/card.php
+++ b/html/card.php
@@ -42,7 +42,7 @@ if (file_exists(getcwd() . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
@@ -56,7 +56,7 @@ require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 try {
     $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
 } catch (\Exception $e) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
 }
 
 if (!isset($config['system']["card_enabled"]) || $config['system']["card_enabled"] !== true) {

--- a/html/dav.php
+++ b/html/dav.php
@@ -42,7 +42,7 @@ if (file_exists(getcwd() . "/Core")) {
 }
 
 if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal dependencies have not been installed. If you are a regular user, this means that you probably downloaded the wrong zip file.</p><p>To install the dependencies manually, execute "<strong>composer install</strong>" in the Ba&iuml;kal root folder.</p>');
 }
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
@@ -55,7 +55,7 @@ require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 try {
     $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
 } catch (\Exception $e) {
-    die('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
+    exit('<h1>Incomplete installation</h1><p>Ba&iuml;kal is missing its configuration file, or its configuration file is unreadable.');
 }
 
 $server = new \Baikal\Core\Server(


### PR DESCRIPTION
The analysis tools pointed out that the `each()` function in PHP is deprecated. I made commit "Remove deprecated unused each() function" It completed removes some code, because actually I found that nothing uses that code anyway. Is that true?

`die()` is a very old function in PHP. The analysis tools now suggest using `exit()`.

This repo has no unit tests, so CI is only going to find things that the analysis tools notice. 