### PR TITLE
apply changes from php-cs-fixer v2.18.0

### DIFF
--- a/Core/Frameworks/Flake/Core/Controller.php
+++ b/Core/Frameworks/Flake/Core/Controller.php
@@ -38,7 +38,7 @@ abstract class Controller extends \Flake\Core\FLObject {
         return $this->aParams;
     }
 
-    static function link(/*[$sParam, $sParam2, ...]*/) {
+    static function link(/*[$sParam, $sParam2, ...]*/ ) {
         return static::buildRoute();
     }
 

--- a/Core/Frameworks/Flake/Util/Router.php
+++ b/Core/Frameworks/Flake/Util/Router.php
@@ -107,7 +107,7 @@ abstract class Router extends \Flake\Core\FLObject {
         return $GLOBALS["ROUTER"]::buildRoute($sRouteForController, $aRewrittenParams);
     }
 
-    static function buildCurrentRoute(/*[$sParam, $sParam2, ...]*/) {
+    static function buildCurrentRoute(/*[$sParam, $sParam2, ...]*/ ) {
         $aParams = func_get_args();
         $sCurrentRoute = $GLOBALS["ROUTER"]::getCurrentRoute();
 
@@ -128,7 +128,7 @@ abstract class Router extends \Flake\Core\FLObject {
 
     # this method is likely to change with every Router implementation
     # should be abstract, but is not, because of PHP's strict standards
-    static function buildRoute($sRoute, $aParams/* [, $sParam, $sParam2, ...] */) {
+    static function buildRoute($sRoute, $aParams/* [, $sParam, $sParam2, ...] */ ) {
     }
 
     # should be abstract, but is not, because of PHP's strict standards

--- a/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
+++ b/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
@@ -55,7 +55,7 @@ class QuestionMarkRewrite extends \Flake\Util\Router {
         return array_shift($aBestMatches);        // first route amongst best matches
     }
 
-    static function buildRoute($sRoute, $aParams = []/* [, $sParam, $sParam2, ...] */) {
+    static function buildRoute($sRoute, $aParams = []/* [, $sParam, $sParam2, ...] */ ) {
         #		$aParams = func_get_args();
         #		array_shift($aParams);	# Stripping $sRoute
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/yaml"  : "^3.4"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "^2.17"
+        "friendsofphp/php-cs-fixer": "^2.18"
     },
     "replace" : {
         "jeromeschneider/baikal" : "self.version"


### PR DESCRIPTION
`php-cs-fixer` v2.18.0 starts reporting code style "errors" like https://travis-ci.org/github/sabre-io/Baikal/jobs/755059156
```
-    static function link(/*[$sParam, $sParam2, ...]*/) {
+    static function link(/*[$sParam, $sParam2, ...]*/ ) {
```

If I adjust the spacing, then v2.17.0 (with prefer-lowest), says that they are wrong.

So this PR bumps the lowest `php-cs-fixer` to 2.18 and applies the code-style changes.

php-cs-fixer had "a lot of stuff" happen in https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.18.0 and specially https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/4943 - somewhere in all that a rule has changed. I doubt that it is worth trying to chase down exactly where.

This gets `master` CI green again.