### PR TITLE
Use latest php-cs-fixer major version 2.19.3

### DIFF
--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -142,7 +142,7 @@ class Server {
         $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($this->pdo);
 
         $nodes = [
-            new \Sabre\CalDAV\Principal\Collection($principalBackend)
+            new \Sabre\CalDAV\Principal\Collection($principalBackend),
         ];
         if ($this->enableCalDAV) {
             $calendarBackend = new \Sabre\CalDAV\Backend\PDO($this->pdo);

--- a/Core/Frameworks/Baikal/Model/AddressBook.php
+++ b/Core/Frameworks/Baikal/Model/AddressBook.php
@@ -75,7 +75,7 @@ class AddressBook extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Address Book token ID",
                 "content" => "The unique identifier for this address book.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -85,12 +85,12 @@ class AddressBook extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Display name",
                 "content" => "This is the name that will be displayed in your CardDAV client.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
             "prop"  => "description",
-            "label" => "Description"
+            "label" => "Description",
         ]));
 
         if ($this->floating()) {

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -42,7 +42,7 @@ class Calendar extends \Flake\Core\Model\Db {
         "calendarorder" => 0,
         "calendarcolor" => "",
         "timezone"      => null,
-        "calendarid"    => 0
+        "calendarid"    => 0,
     ];
     protected $oCalendar; # Baikal\Model\Calendar\Calendar
 
@@ -182,7 +182,7 @@ class Calendar extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Calendar token ID",
                 "content" => "The unique identifier for this calendar.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -192,7 +192,7 @@ class Calendar extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Display name",
                 "content" => "This is the name that will be displayed in your CalDAV client.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -204,12 +204,12 @@ class Calendar extends \Flake\Core\Model\Db {
                     "content" => "This is the color that will be displayed in your CalDAV client.<br/>" .
                     "Must be supplied in format '#RRGGBBAA' (alpha channel optional) with hexadecimal values.<br/>" .
                     "This value is optional.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
             "prop"  => "description",
-            "label" => "Description"
+            "label" => "Description",
         ]));
 
         $oMorpho->add(new \Formal\Element\Checkbox([

--- a/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
@@ -33,7 +33,7 @@ class Calendar extends \Flake\Core\Model\Db {
     const LABELFIELD = "components";
 
     protected $aData = [
-        "components" => ""
+        "components" => "",
     ];
 
     function hasInstances() {

--- a/Core/Frameworks/Baikal/Model/Config/Database.php
+++ b/Core/Frameworks/Baikal/Model/Config/Database.php
@@ -64,7 +64,7 @@ class Database extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Text([
             "prop"  => "mysql_host",
             "label" => "MySQL host",
-            "help"  => "Host ip or name, including ':portnumber' if port is not the default one (3306)"
+            "help"  => "Host ip or name, including ':portnumber' if port is not the default one (3306)",
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([

--- a/Core/Frameworks/Baikal/Model/Config/Standard.php
+++ b/Core/Frameworks/Baikal/Model/Config/Standard.php
@@ -42,7 +42,7 @@ class Standard extends \Baikal\Model\Config {
         // While not editable as will change admin & any existing user passwords,
         // could be set to different value when migrating from legacy config
         "auth_realm"            => "BaikalDAV",
-        "base_uri"              => ""
+        "base_uri"              => "",
     ];
 
     function __construct() {
@@ -62,24 +62,24 @@ class Standard extends \Baikal\Model\Config {
 
         $oMorpho->add(new \Formal\Element\Checkbox([
             "prop"  => "card_enabled",
-            "label" => "Enable CardDAV"
+            "label" => "Enable CardDAV",
         ]));
 
         $oMorpho->add(new \Formal\Element\Checkbox([
             "prop"  => "cal_enabled",
-            "label" => "Enable CalDAV"
+            "label" => "Enable CalDAV",
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
             "prop"  => "invite_from",
             "label" => "Email invite sender address",
-            "help"  => "Leave empty to disable sending invite emails"
+            "help"  => "Leave empty to disable sending invite emails",
         ]));
 
         $oMorpho->add(new \Formal\Element\Listbox([
             "prop"    => "dav_auth_type",
             "label"   => "WebDAV authentication type",
-            "options" => ["Digest", "Basic", "Apache"]
+            "options" => ["Digest", "Basic", "Apache"],
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -212,7 +212,7 @@ class User extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Username",
                 "content" => "The login for this user account. It has to be unique.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -222,13 +222,13 @@ class User extends \Flake\Core\Model\Db {
             "popover"    => [
                 "title"   => "Display name",
                 "content" => "This is the name that will be displayed in your CalDAV/CardDAV clients.",
-            ]
+            ],
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
             "prop"       => "email",
             "label"      => "Email",
-            "validation" => "required,email"
+            "validation" => "required,email",
         ]));
 
         $oMorpho->add(new \Formal\Element\Password([
@@ -251,12 +251,12 @@ class User extends \Flake\Core\Model\Db {
 
             $oMorpho->element("password")->setOption("popover", [
                 "title"   => "Password",
-                "content" => "Write something here only if you want to change the user password."
+                "content" => "Write something here only if you want to change the user password.",
             ]);
 
             $oMorpho->element("passwordconfirm")->setOption("popover", [
                 "title"   => "Confirm password",
-                "content" => "Write something here only if you want to change the user password."
+                "content" => "Write something here only if you want to change the user password.",
             ]);
 
             $oMorpho->element("password")->setOption("placeholder", $sNotice);

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
@@ -61,7 +61,7 @@ class Initialize extends \Flake\Core\Controller {
         }
 
         $this->oForm = $this->oModel->formForThisModelInstance([
-            "close" => false
+            "close" => false,
         ]);
 
         if ($this->oForm->submitted()) {

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -268,7 +268,7 @@ HTML;
                 $stmt->execute([
                     md5($row['carddata']),
                     strlen($row['carddata']),
-                    $row['id']
+                    $row['id'],
                 ]);
             }
             $this->aSuccess[] = 'etag and size was recalculated for cards';
@@ -304,7 +304,7 @@ HTML;
                 $stmt1->execute([
                     'addressbooks/' . basename($row['uri']),
                     '{http://calendarserver.org/ns/}me-card',
-                    serialize(new \Sabre\DAV\Xml\Property\Href($row['vcardurl']))
+                    serialize(new \Sabre\DAV\Xml\Property\Href($row['vcardurl'])),
                 ]);
             }
             $this->aSuccess[] = 'vcardurl was migrated to the propertystorage system';

--- a/Core/Frameworks/BaikalAdmin/Controller/Settings/Standard.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Settings/Standard.php
@@ -47,7 +47,7 @@ class Standard extends \Flake\Core\Controller {
         }
 
         $this->oForm = $this->oModel->formForThisModelInstance([
-            "close" => false
+            "close" => false,
         ]);
 
         if ($this->oForm->submitted()) {

--- a/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/AddressBooks.php
@@ -102,7 +102,7 @@ class AddressBooks extends \Flake\Core\Controller {
     protected function initForm() {
         if ($this->actionEditRequested() || $this->actionNewRequested()) {
             $aOptions = [
-                "closeurl" => $this->linkHome()
+                "closeurl" => $this->linkHome(),
             ];
 
             $this->oForm = $this->oModel->formForThisModelInstance($aOptions);
@@ -123,7 +123,7 @@ class AddressBooks extends \Flake\Core\Controller {
     function linkNew() {
         return self::buildRoute([
             "user" => $this->currentUserId(),
-            "new"  => 1
+            "new"  => 1,
         ]) . "#form";
     }
 
@@ -165,7 +165,7 @@ class AddressBooks extends \Flake\Core\Controller {
     function linkEdit(\Baikal\Model\AddressBook $oModel) {
         return self::buildRoute([
             "user" => $this->currentUserId(),
-            "edit" => $oModel->get("id")
+            "edit" => $oModel->get("id"),
         ]) . "#form";
     }
 
@@ -197,7 +197,7 @@ class AddressBooks extends \Flake\Core\Controller {
     function linkDelete(\Baikal\Model\AddressBook $oModel) {
         return self::buildRoute([
             "user"   => $this->currentUserId(),
-            "delete" => $oModel->get("id")
+            "delete" => $oModel->get("id"),
         ]) . "#message";
     }
 
@@ -205,7 +205,7 @@ class AddressBooks extends \Flake\Core\Controller {
         return self::buildRoute([
             "user"    => $this->currentUserId(),
             "delete"  => $oModel->get("id"),
-            "confirm" => 1
+            "confirm" => 1,
         ]) . "#message";
     }
 

--- a/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/User/Calendars.php
@@ -98,7 +98,7 @@ class Calendars extends \Flake\Core\Controller {
     protected function initForm() {
         if ($this->actionEditRequested() || $this->actionNewRequested()) {
             $aOptions = [
-                "closeurl" => $this->linkHome()
+                "closeurl" => $this->linkHome(),
             ];
 
             $this->oForm = $this->oModel->formForThisModelInstance($aOptions);
@@ -119,7 +119,7 @@ class Calendars extends \Flake\Core\Controller {
     function linkNew() {
         return self::buildRoute([
             "user" => $this->currentUserId(),
-            "new"  => 1
+            "new"  => 1,
         ]) . "#form";
     }
 
@@ -168,7 +168,7 @@ class Calendars extends \Flake\Core\Controller {
     function linkEdit(\Baikal\Model\Calendar $oModel) {
         return self::buildRoute([
             "user" => $this->currentUserId(),
-            "edit" => $oModel->get("id")
+            "edit" => $oModel->get("id"),
         ]) . "#form";
     }
 
@@ -200,7 +200,7 @@ class Calendars extends \Flake\Core\Controller {
     function linkDelete(\Baikal\Model\Calendar $oModel) {
         return self::buildRoute([
             "user"   => $this->currentUserId(),
-            "delete" => $oModel->get("id")
+            "delete" => $oModel->get("id"),
         ]) . "#message";
     }
 
@@ -208,7 +208,7 @@ class Calendars extends \Flake\Core\Controller {
         return self::buildRoute([
             "user"    => $this->currentUserId(),
             "delete"  => $oModel->get("id"),
-            "confirm" => 1
+            "confirm" => 1,
         ]) . "#message";
     }
 

--- a/Core/Frameworks/BaikalAdmin/Controller/Users.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Users.php
@@ -101,7 +101,7 @@ class Users extends \Flake\Core\Controller {
     protected function initForm() {
         if ($this->actionEditRequested() || $this->actionNewRequested()) {
             $aOptions = [
-                "closeurl" => self::link()
+                "closeurl" => self::link(),
             ];
 
             $this->oForm = $this->oModel->formForThisModelInstance($aOptions);
@@ -213,26 +213,26 @@ class Users extends \Flake\Core\Controller {
 
     function linkNew() {
         return self::buildRoute([
-            "new" => 1
+            "new" => 1,
         ]) . "#form";
     }
 
     static function linkEdit(\Baikal\Model\User $user) {
         return self::buildRoute([
-            "edit" => $user->get("id")
+            "edit" => $user->get("id"),
         ]) . "#form";
     }
 
     static function linkDelete(\Baikal\Model\User $user) {
         return self::buildRoute([
-            "delete" => $user->get("id")
+            "delete" => $user->get("id"),
         ]) . "#message";
     }
 
     static function linkDeleteConfirm(\Baikal\Model\User $user) {
         return self::buildRoute([
             "delete"  => $user->get("id"),
-            "confirm" => 1
+            "confirm" => 1,
         ]) . "#message";
     }
 

--- a/Core/Frameworks/BaikalAdmin/Resources/GlyphiconsPro/generate-sprite.php
+++ b/Core/Frameworks/BaikalAdmin/Resources/GlyphiconsPro/generate-sprite.php
@@ -387,7 +387,7 @@ function generateSprite($aSymbols, $iCols, $iRows, $iPngWidth, $iPngHeight, $sCl
             "x"      => round($iX),
             "y"      => round($iY),
             "width"  => ceil($iSymbolWidth),
-            "height" => ceil($iSymbolHeight)
+            "height" => ceil($iSymbolHeight),
         ];
 
         ++$iKey;

--- a/Core/Frameworks/BaikalAdmin/config.php
+++ b/Core/Frameworks/BaikalAdmin/config.php
@@ -34,5 +34,5 @@ $GLOBALS["ROUTES"] = [
     "users/addressbooks" => "\BaikalAdmin\Route\User\AddressBooks",
     "settings/standard"  => "\BaikalAdmin\Route\Settings\Standard",
     "settings/database"  => "\BaikalAdmin\Route\Settings\Database",
-    "logout"             => "\BaikalAdmin\Route\Logout"
+    "logout"             => "\BaikalAdmin\Route\Logout",
 ];

--- a/Core/Frameworks/Flake/Core/Controller.php
+++ b/Core/Frameworks/Flake/Core/Controller.php
@@ -38,7 +38,7 @@ abstract class Controller extends \Flake\Core\FLObject {
         return $this->aParams;
     }
 
-    static function link(/*[$sParam, $sParam2, ...]*/ ) {
+    static function link(/*[$sParam, $sParam2, ...]*/) {
         return static::buildRoute();
     }
 

--- a/Core/Frameworks/Flake/Core/Requester/Sql.php
+++ b/Core/Frameworks/Flake/Core/Requester/Sql.php
@@ -122,7 +122,7 @@ class Sql extends \Flake\Core\Requester {
             ],
             [
                 $sField,
-                $sValue
+                $sValue,
             ],
             $sWrap
         );

--- a/Core/Frameworks/Flake/Util/Router.php
+++ b/Core/Frameworks/Flake/Util/Router.php
@@ -107,7 +107,7 @@ abstract class Router extends \Flake\Core\FLObject {
         return $GLOBALS["ROUTER"]::buildRoute($sRouteForController, $aRewrittenParams);
     }
 
-    static function buildCurrentRoute(/*[$sParam, $sParam2, ...]*/ ) {
+    static function buildCurrentRoute(/*[$sParam, $sParam2, ...]*/) {
         $aParams = func_get_args();
         $sCurrentRoute = $GLOBALS["ROUTER"]::getCurrentRoute();
 
@@ -128,7 +128,7 @@ abstract class Router extends \Flake\Core\FLObject {
 
     # this method is likely to change with every Router implementation
     # should be abstract, but is not, because of PHP's strict standards
-    static function buildRoute($sRoute, $aParams/* [, $sParam, $sParam2, ...] */ ) {
+    static function buildRoute($sRoute, $aParams/* [, $sParam, $sParam2, ...] */) {
     }
 
     # should be abstract, but is not, because of PHP's strict standards

--- a/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
+++ b/Core/Frameworks/Flake/Util/Router/QuestionMarkRewrite.php
@@ -55,7 +55,7 @@ class QuestionMarkRewrite extends \Flake\Util\Router {
         return array_shift($aBestMatches);        // first route amongst best matches
     }
 
-    static function buildRoute($sRoute, $aParams = []/* [, $sParam, $sParam2, ...] */ ) {
+    static function buildRoute($sRoute, $aParams = []/* [, $sParam, $sParam2, ...] */) {
         #		$aParams = func_get_args();
         #		array_shift($aParams);	# Stripping $sRoute
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/yaml"  : "^3.4"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "2.18.0",
+        "friendsofphp/php-cs-fixer": "2.19.3",
         "phpstan/phpstan": "^1.2"
     },
     "replace" : {


### PR DESCRIPTION
Before trying to upgrade to php-cs-fixer major version 3, first bump to the latest v2 release.
https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/tag/v2.19.3

This cs-fixer release applies the rule that the last array entry should have a comma at the end (ready for a next array entry to be added in the future, if needed) That has been valid syntax since "a long time" and certainly in all PHP 7 and PHP 8 versions.