### PR TITLE
Update to php-cs-fixer v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        cs-fixer: [ true ]
+        include:
+          - php-versions: '7.1'
+            cs-fixer: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,10 +42,15 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      - name: Remove php-cs-fixer dependency when not used
+        if: matrix.cs-fixer == false
+        run: composer remove --dev friendsofphp/php-cs-fixer
+
       - name: Install composer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Analysis (PHP CS-Fixer)
+        if: matrix.cs-fixer == true
         run: php vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Code Analysis (PHPStan)

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ vendor
 nbproject
 
 # Tests
+.php-cs-fixer.cache
 .php_cs.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,13 +1,13 @@
 <?php
 
-$config = PhpCsFixer\Config::create();
+$config = new PhpCsFixer\Config;
 $config->getFinder()
     ->exclude('vendor')
     ->in(__DIR__);
 $config->setRules([
     '@PSR2' => true,
     '@Symfony' => true,
-    'binary_operator_spaces' => ['align_double_arrow' => true],
+    'binary_operator_spaces' => [],
     'braces' => ['position_after_functions_and_oop_constructs' => 'same'],
     'concat_space' => ['spacing' => 'one'],
     'no_superfluous_phpdoc_tags' => false,
@@ -15,7 +15,7 @@ $config->setRules([
     'phpdoc_align' => false,
     'single_line_comment_style' => false,
     'single_quote' => false,
-    'trailing_comma_in_multiline_array' => false,
+    'trailing_comma_in_multiline' => true,
     'visibility_required' => false,
     'yoda_style' => false
 ]);

--- a/Core/Frameworks/Flake/Util/Tools.php
+++ b/Core/Frameworks/Flake/Util/Tools.php
@@ -736,7 +736,7 @@ TEST;
             if ($len - $headerlen - 2 < 8) {
                 return false;    // invalid
             }
-            $calccrc = crc32(substr($data, 0, $headerlen)) & 0xffff;
+            $calccrc = crc32(substr($data, 0, $headerlen)) & 0xFFFF;
             $headercrc = unpack("v", substr($data, $headerlen, 2));
             $headercrc = $headercrc[1];
             if ($headercrc != $calccrc) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/yaml"  : "^3.4"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "2.19.3",
+        "friendsofphp/php-cs-fixer": "3.3.2",
         "phpstan/phpstan": "^1.2"
     },
     "replace" : {


### PR DESCRIPTION
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.3.0/UPGRADE-v3.md

`php-cs-fixer` v3 does not support PHP 7.1. I adjusted the CI to not run it in the PHP 7.1 pipeline.

`align_double_arrow` is no longer a setting for `binary_operator_spaces`. The default setting `[]` works.

`trailing_comma_in_multiline_array` changes to `trailing_comma_in_multiline` with some settings. The default enforces the trailing comma on all multiline "things"

It now likes hex to be written in uppercase - `0xFFFF` rather than `0xffff` - that seems a reasonable change.

This major version supports PHP 8.1. So using it will help with next running PHP 8.1 in CI in PR #1068 