### PR TITLE
Pin psr/log to 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php"           : "^7.2 || ^8.0",
         "sabre/dav"     : "~4.3.0",
         "twig/twig"     : "~2.14.8",
-        "symfony/yaml"  : "^3.4"
+        "symfony/yaml"  : "^3.4",
+        "psr/log"       : "^1"
     },
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "3.3.2",


### PR DESCRIPTION
Recent versions of sabre/dav allow psr/log 1.x, 2.x and 3.x.
In order to still support php 7.2, we need to pin it down to 1.x

Fixes #1078