### PR TITLE
fix htmlspecialchars() while trying to edit calendar

### DIFF
--- a/Core/Frameworks/Formal/Element/Text.php
+++ b/Core/Frameworks/Formal/Element/Text.php
@@ -66,7 +66,7 @@ class Text extends \Formal\Element {
             $placeholder = " placeholder=\"" . htmlspecialchars($sPlaceHolder) . "\" ";
         }
 
-        $clientvalue = htmlspecialchars($value);
+        $clientvalue = htmlspecialchars($value ?? '');
 
         $sInputType = $this->inputtype();
 


### PR DESCRIPTION
Hello, This is my first pull request ever so I apologize if it's not quite up to par.

I was having an issue in my Docker container editing a calendar so I found a fix and pushed it to my Docker setup.

This fix should help with #1117

This is the message during the error
<img width="1319" alt="before" src="https://user-images.githubusercontent.com/17791367/173961290-38b1aa9e-82d0-4d53-9869-30897eceb619.png">

This is after I pushed the fix to my container. You're now able to click the blue "Edit" button and edit the calendar!
<img width="1179" alt="after fix" src="https://user-images.githubusercontent.com/17791367/173961382-34792cff-5dcf-4f1a-9eab-298951288179.png">

