### PR TITLE
Fix typo in comment and phpstan

### DIFF
--- a/Core/Frameworks/Baikal/WWWRoot/index.php
+++ b/Core/Frameworks/Baikal/WWWRoot/index.php
@@ -45,7 +45,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrapping Baïkal

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/index.php
@@ -46,7 +46,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrap BaikalAdmin

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -53,7 +53,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 
 require PROJECT_PATH_ROOT . "vendor/autoload.php";
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrap BaikalAdmin

--- a/Core/Frameworks/Flake/Core/Datastructure/ChainLink.php
+++ b/Core/Frameworks/Flake/Core/Datastructure/ChainLink.php
@@ -60,6 +60,7 @@ abstract class ChainLink implements \Flake\Core\Datastructure\Chainable {
         $this->__container->offsetUnset($offset);
     }
 
+    #[\ReturnTypeWillChange]
     function &offsetGet($offset) {
         if (is_null($this->__container)) {
             return null;
@@ -74,10 +75,12 @@ abstract class ChainLink implements \Flake\Core\Datastructure\Chainable {
         $this->__container->rewind();
     }
 
+    #[\ReturnTypeWillChange]
     function current() {
         return $this->__container->current();
     }
 
+    #[\ReturnTypeWillChange]
     function key() {
         return $this->__container->key();
     }

--- a/html/cal.php
+++ b/html/cal.php
@@ -47,7 +47,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrapping Baïkal

--- a/html/card.php
+++ b/html/card.php
@@ -47,7 +47,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrapping Baïkal

--- a/html/dav.php
+++ b/html/dav.php
@@ -46,7 +46,7 @@ if (!file_exists(PROJECT_PATH_ROOT . 'vendor/')) {
 }
 require PROJECT_PATH_ROOT . 'vendor/autoload.php';
 
-# Bootstraping Flake
+# Bootstrapping Flake
 \Flake\Framework::bootstrap();
 
 # Bootstrapping Baïkal


### PR DESCRIPTION
In PHP 8.1, `ArrayAccess` has return types specified for methods like `offsetGet` and so if a class extends `ArrayAccess` then it now needs to specify the return type (in this case `mixed`).

But the `mixed` return type is only available form PHP 8.0 onward. So we can't write that because we still support PHP 7.2 7.3 7.4.

So we have to add https://php.watch/versions/8.1/internal-method-return-types#ReturnTypeWillChange and that suppresses the deprecation notice that PHP 8.1 emits. After PHP 7 is dropped (in the future) then we need to explicitly mention the return type.