### PR TITLE
feat(mysql): add PDO connection options from config

### DIFF
--- a/Core/Frameworks/Flake/Core/Database/Mysql.php
+++ b/Core/Frameworks/Flake/Core/Database/Mysql.php
@@ -33,7 +33,7 @@ class Mysql extends \Flake\Core\Database {
     protected $sUsername = "";
     protected $sPassword = "";
 
-    function __construct($sHost, $sDbName, $sUsername, $sPassword) {
+    function __construct($sHost, $sDbName, $sUsername, $sPassword, $options = []) {
         $this->sHost = $sHost;
         $this->sDbName = $sDbName;
         $this->sUsername = $sUsername;
@@ -42,7 +42,8 @@ class Mysql extends \Flake\Core\Database {
         $this->oDb = new \PDO(
             'mysql:host=' . $this->sHost . ';dbname=' . $this->sDbName,
             $this->sUsername,
-            $this->sPassword
+            $this->sPassword,
+            $options
         );
         $this->oDb->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
     }

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -313,7 +313,8 @@ class Framework extends \Flake\Core\Framework {
                 $config['database']['mysql_host'],
                 $config['database']['mysql_dbname'],
                 $config['database']['mysql_username'],
-                $config['database']['mysql_password']
+                $config['database']['mysql_password'],
+                $config['database']['mysql_options'] ?? []
             );
 
             # We now setup t6he connexion to use UTF8

--- a/config/baikal.yaml.dist
+++ b/config/baikal.yaml.dist
@@ -18,5 +18,5 @@ database:
     mysql_username: 'baikal'
     mysql_password: 'baikal'
     mysql_options:
-        !php/const:PDO::MYSQL_ATTR_SSL_CA: ""
-        !php/const:PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: false
+        1009: "ca.crt"
+        1014: false

--- a/config/baikal.yaml.dist
+++ b/config/baikal.yaml.dist
@@ -17,3 +17,6 @@ database:
     mysql_dbname: 'baikal'
     mysql_username: 'baikal'
     mysql_password: 'baikal'
+    mysql_options:
+        !php/const:PDO::MYSQL_ATTR_SSL_CA: ""
+        !php/const:PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: false


### PR DESCRIPTION
To use Baikal with a mysql server that require SSL.

https://callisto.digital/posts/php/enable-mysql-over-ssl-in-php-pdo/

Didnt find the right way to use php const inside the YAML :-/