### PR TITLE
Add dependabot to create GH action version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Currently there is no package manager or similar for GH Actions to manage the dependencies.
Dependabot offers to monitor the workflow scripts and propose new versions as PR.
Since GH Actions rarely change and no resources should be wasted, a repetition of one month is sufficient.

I would recommend to add the dependabot.yml to every repository with GH action script.