### PR TITLE
Adds support for HTML Tags within form popovers

### DIFF
--- a/Core/Frameworks/Formal/Element/Text.php
+++ b/Core/Frameworks/Formal/Element/Text.php
@@ -84,6 +84,7 @@ class Text extends \Formal\Element {
 
             $popover = " title=\"" . htmlspecialchars($aPopover["title"]) . "\" ";
             $popover .= " data-content=\"" . htmlspecialchars($aPopover["content"]) . "\" ";
+            $popover .= " data-html=\"true\"";
         }
 
         $sHtml = <<<HTML


### PR DESCRIPTION
This changes the Form/Element/Text class
Adds `data-html` attribute on the input field.

This leads to Bootstrap interpreting the HTML Tags in the `data-content` attribute instead of escaping them.

This has previously been an issue with the popover for the Color in the Add/Edit Calendar form. See [here](https://github.com/sabre-io/Baikal/blob/aa7e340113545f8be18b6e8c44d001fc4e684526/Core/Frameworks/Baikal/Model/Calendar.php#L204C27-L204C27)