### PR TITLE
Add PostgreSQL backend

### DIFF
--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -45,8 +45,8 @@ class Tools {
 
         # Asserting PDO::SQLite or PDO::MySQL
         $aPDODrivers = \PDO::getAvailableDrivers();
-        if (!in_array('sqlite', $aPDODrivers, true) && !in_array('mysql', $aPDODrivers, true)) {
-            exit('<strong>Baikal Fatal Error</strong>: Both <strong>PDO::sqlite</strong> and <strong>PDO::mysql</strong> are unavailable. One of them at least is required by Baikal.');
+        if (!in_array('sqlite', $aPDODrivers, true) && !in_array('mysql', $aPDODrivers, true) && !in_array('pgsql', $aPDODrivers, true)) {
+            exit('<strong>Baikal Fatal Error</strong>: None of <strong>PDO::sqlite</strong>, <strong>PDO::mysql</strong> or <strong>PDO::pgsql</strong> are available. One of them at least is required by Baikal.');
         }
 
         # Assert that the temp folder is writable

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -244,7 +244,7 @@ class Calendar extends \Flake\Core\Model\Db {
 
     function hasInstances() {
         $rSql = $GLOBALS["DB"]->exec_SELECTquery(
-            "count(*)",
+            "count(*) as count",
             "calendarinstances",
             "calendarid='" . $this->aData["calendarid"] . "'"
         );
@@ -254,7 +254,7 @@ class Calendar extends \Flake\Core\Model\Db {
         } else {
             reset($aRs);
 
-            return $aRs["count(*)"] > 1;
+            return $aRs["count"] > 1;
         }
     }
 

--- a/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar/Calendar.php
@@ -38,7 +38,7 @@ class Calendar extends \Flake\Core\Model\Db {
 
     function hasInstances() {
         $rSql = $GLOBALS["DB"]->exec_SELECTquery(
-            "count(*)",
+            "count(*) as count",
             "calendarinstances",
             "calendarid='" . $this->aData["id"] . "'"
         );
@@ -48,7 +48,7 @@ class Calendar extends \Flake\Core\Model\Db {
         } else {
             reset($aRs);
 
-            return $aRs["count(*)"] > 1;
+            return $aRs["count"] > 1;
         }
     }
 

--- a/Core/Frameworks/Baikal/Model/Config/Database.php
+++ b/Core/Frameworks/Baikal/Model/Config/Database.php
@@ -31,12 +31,16 @@ class Database extends \Baikal\Model\Config {
     # Default values
     protected $aData = [
         "sqlite_file"    => PROJECT_PATH_SPECIFIC . "db/db.sqlite",
-        "mysql"          => false,
+        "backend"        => "",
         "mysql_host"     => "",
         "mysql_dbname"   => "",
         "mysql_username" => "",
         "mysql_password" => "",
         "encryption_key" => "",
+        "pgsql_host"     => "",
+        "pgsql_dbname"   => "",
+        "pgsql_username" => "",
+        "pgsql_password" => "",
     ];
 
     function __construct() {
@@ -46,19 +50,20 @@ class Database extends \Baikal\Model\Config {
     function formMorphologyForThisModelInstance() {
         $oMorpho = new \Formal\Form\Morphology();
 
+        $oMorpho->add(new \Formal\Element\Listbox([
+            "prop"       => "backend",
+            "label"      => "Database Backend",
+            "validation" => "required",
+            "options"    => ['sqlite', 'mysql', 'pgsql'],
+            "refreshonchange" => true,
+        ]));
+
         $oMorpho->add(new \Formal\Element\Text([
             "prop"       => "sqlite_file",
             "label"      => "SQLite file path",
             "validation" => "required",
             "inputclass" => "input-xxlarge",
             "help"       => "The absolute server path to the SQLite file",
-        ]));
-
-        $oMorpho->add(new \Formal\Element\Checkbox([
-            "prop"            => "mysql",
-            "label"           => "Use MySQL",
-            "help"            => "If checked, Baïkal will use MySQL instead of SQLite.",
-            "refreshonchange" => true,
         ]));
 
         $oMorpho->add(new \Formal\Element\Text([
@@ -80,6 +85,27 @@ class Database extends \Baikal\Model\Config {
         $oMorpho->add(new \Formal\Element\Password([
             "prop"  => "mysql_password",
             "label" => "MySQL password",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop" => "pgsql_host",
+            "label" => "PostgreSQL host",
+            "help" => "Host ip or name, including <strong>':portnumber'</strong> if port is not the default one (?)",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop" => "pgsql_dbname",
+            "label" => "PostgreSQL database name",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Text([
+            "prop" => "pgsql_username",
+            "label" => "PostgreSQL username",
+        ]));
+
+        $oMorpho->add(new \Formal\Element\Password([
+            "prop" => "pgsql_password",
+            "label" => "PostgreSQL password",
         ]));
 
         return $oMorpho;

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Initialize.php
@@ -82,8 +82,12 @@ class Initialize extends \Flake\Core\Controller {
 
                 # Default: PDO::SQLite or PDO::MySQL ?
                 $aPDODrivers = \PDO::getAvailableDrivers();
-                if (!in_array('sqlite', $aPDODrivers)) {    # PDO::MySQL is already asserted in \Baikal\Core\Tools::assertEnvironmentIsOk()
-                    $oDatabaseConfig->set("mysql", true);
+                if (in_array('sqlite', $aPDODrivers)) {    # PDO::MySQL is already asserted in \Baikal\Core\Tools::assertEnvironmentIsOk()
+                    $oDatabaseConfig->set("backend", 'sqlite');
+                } elseif (in_array('mysql', $aPDODrivers)) {
+                    $oDatabaseConfig->set("backend", 'mysql');
+                } else {
+                    $oDatabaseConfig->set("backend", 'pgsql');
                 }
 
                 $oDatabaseConfig->persist();

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -505,6 +505,14 @@ SQL
             $this->aSuccess[] = 'Updated default values in calendarinstances table';
         }
 
+        if (version_compare($sVersionFrom, '0.10.0', '<')) {
+            $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
+
+            $oConfig = new \Baikal\Model\Config\Database();
+            $oConfig->set("backend", intval($config['database']['mysql']) === 1 ? 'mysql' : 'sqlite');
+            $oConfig->persist();
+        }
+
         $this->updateConfiguredVersion($sVersionTo);
 
         return true;

--- a/Core/Frameworks/Flake/Core/Database/Pgsql.php
+++ b/Core/Frameworks/Flake/Core/Database/Pgsql.php
@@ -1,0 +1,68 @@
+<?php
+
+#################################################################
+#  Copyright notice
+#
+#  (c) 2013 Kim Lidström <kim@dxtr.im>
+#  All rights reserved
+#
+#  http://flake.codr.fr
+#
+#  This script is part of the Flake project. The Flake
+#  project is free software; you can redistribute it
+#  and/or modify it under the terms of the GNU General Public
+#  License as published by the Free Software Foundation; either
+#  version 2 of the License, or (at your option) any later version.
+#
+#  The GNU General Public License can be found at
+#  http://www.gnu.org/copyleft/gpl.html.
+#
+#  This script is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  This copyright notice MUST APPEAR in all copies of the script!
+#################################################################
+
+namespace Flake\Core\Database;
+
+class Pgsql extends \Flake\Core\Database {
+    protected $oDb = false; // current DB link
+    protected $debugOutput = false;
+    protected $store_lastBuiltQuery = true;
+    protected $debug_lastBuiltQuery = "";
+    protected $sHost = "";
+    protected $sDbName = "";
+    protected $sUsername = "";
+    protected $sPassword = "";
+
+    public function __construct($sHost, $sDbName, $sUsername, $sPassword) {
+        $this->sHost = $sHost;
+        $this->sDbName = $sDbName;
+        $this->sUsername = $sUsername;
+        $this->sPassword = $sPassword;
+
+        $this->oDb = new \PDO(
+            'pgsql:host=' . $this->sHost . ';dbname=' . $this->sDbName,
+            $this->sUsername,
+            $this->sPassword
+        );
+    }
+
+    public function tables() {
+        $aTables = [];
+
+        $sSql  = "SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname = 'public'";
+        $oStmt = $this->query($sSql);
+
+        while (($aRs = $oStmt->fetch()) !== false) {
+            $aTables[] = array_shift($aRs);
+        }
+
+        asort($aTables);
+        reset($aTables);
+
+        return $aTables;
+    }
+}

--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -273,8 +273,12 @@ class Framework extends \Flake\Core\Framework {
         if (defined("BAIKAL_CONTEXT_INSTALL") && (!isset($config['system']['configured_version']) || $config['system']['configured_version'] === BAIKAL_VERSION)) {
             return true;
         }
-        if ($config['database']['mysql'] === true) {
+        # Config key 'mysql' kept for backwards compatibility
+        $legacyMysql = key_exists('mysql', $config['database']) && $config['database']['mysql'] === true;
+        if ($legacyMysql || (key_exists('backend', $config['database']) && $config['database']['backend'] === 'mysql')) {
             self::initDbMysql($config);
+        } elseif (key_exists('backend', $config['database']) && $config['database']['backend'] === 'pgsql') {
+            self::initDbPgsql($config);
         } else {
             self::initDbSqlite($config);
         }
@@ -337,6 +341,38 @@ class Framework extends \Flake\Core\Framework {
         }
 
         return true;
+    }
+
+    protected static function initDbPgsql(array $config) {
+        if (!$config['database']['pgsql_host']) {
+            exit("<h3>The constant PROJECT_DB_PGSQL_HOST, containing the PostgreSQL host name, is not set.<br />You should set it in config/baikal.yaml</h3>");
+        }
+
+        if (!$config['database']['pgsql_dbname']) {
+            exit("<h3>The constant PROJECT_DB_PGSQL_DBNAME, containing the PostgreSQL database name, is not set.<br />You should set it in config/baikal.yaml</h3>");
+        }
+
+        try {
+            $GLOBALS["DB"] = new \Flake\Core\Database\Pgsql(
+                $config['database']['pgsql_host'],
+                $config['database']['pgsql_dbname'],
+                $config['database']['pgsql_username'],
+                $config['database']['pgsql_password']
+            );
+
+            $GLOBALS["DB"]->query("SET NAMES 'UTF8'");
+        } catch (\Exception $e) {
+            $message = "Baïkal was not able to establish a connection to the configured PostgreSQL database (as configured in config/baikal.yaml).";
+            if (!$config['database']['pgsql_username']) {
+                exit("<h3>$message Note: The constant PROJECT_DB_PGSQL_USERNAME, containing the PostgreSQL database username, is not set. If your database requires a username you should set it in config/baikal.yaml.</h3>");
+            }
+
+            if ($config['database']['pgsql_password'] === null) {
+                exit("<h3>$message Note: The constant PROJECT_DB_PGSQL_PASSWORD, containing the PostgreSQL database password, is not set. If your database requires a password you should set it in config/baikal.yaml.</h3>");
+            }
+
+            exit("<h3>$message</h3>");
+        }
     }
 
     static function isDBInitialized() {

--- a/Core/Resources/Db/PgSQL/db.sql
+++ b/Core/Resources/Db/PgSQL/db.sql
@@ -1,0 +1,142 @@
+
+CREATE TABLE addressbooks (
+    id SERIAL PRIMARY KEY,
+    principaluri TEXT,
+    displayname VARCHAR(255),
+    uri TEXT,
+    description TEXT,
+    synctoken INT CHECK (synctoken > 0) NOT NULL DEFAULT '1'
+);
+
+CREATE TABLE cards (
+    id SERIAL PRIMARY KEY,
+    addressbookid INT CHECK (addressbookid > 0) NOT NULL,
+    carddata TEXT,
+    uri TEXT,
+    lastmodified INT CHECK (lastmodified > 0),
+    etag TEXT,
+    size INT CHECK (size > 0) NOT NULL
+);
+
+CREATE TABLE addressbookchanges (
+    id SERIAL PRIMARY KEY,
+    uri TEXT NOT NULL,
+    synctoken INT CHECK (synctoken > 0) NOT NULL,
+    addressbookid INT CHECK (addressbookid > 0) NOT NULL,
+    operation SMALLINT NOT NULL
+);
+
+CREATE INDEX addressbookid_synctoken ON addressbookchanges (addressbookid, synctoken);
+
+CREATE TABLE calendarobjects (
+    id SERIAL PRIMARY KEY,
+    calendardata TEXT,
+    uri TEXT,
+    calendarid INTEGER CHECK (calendarid > 0) NOT NULL,
+    lastmodified INT CHECK (lastmodified > 0),
+    etag TEXT,
+    size INT CHECK (size > 0) NOT NULL,
+    componenttype TEXT,
+    firstoccurence INT CHECK (firstoccurence > 0),
+    lastoccurence INT CHECK (lastoccurence > 0),
+    uid TEXT
+);
+
+CREATE TABLE calendars (
+    id SERIAL PRIMARY KEY,
+    synctoken INTEGER CHECK (synctoken > 0) NOT NULL DEFAULT '1',
+    components TEXT
+);
+
+CREATE TABLE calendarinstances (
+    id SERIAL PRIMARY KEY,
+    calendarid INTEGER CHECK (calendarid > 0) NOT NULL,
+    principaluri TEXT,
+    access SMALLINT NOT NULL DEFAULT '1',
+    displayname VARCHAR(100),
+    uri TEXT,
+    description TEXT,
+    calendarorder INT CHECK (calendarorder >= 0) NOT NULL DEFAULT '0',
+    calendarcolor TEXT,
+    timezone TEXT,
+    transparent SMALLINT NOT NULL DEFAULT '0',
+    share_href TEXT,
+    share_displayname VARCHAR(100),
+    share_invitestatus SMALLINT NOT NULL DEFAULT '2'
+);
+
+CREATE TABLE calendarchanges (
+    id SERIAL PRIMARY KEY,
+    uri TEXT NOT NULL,
+    synctoken INT CHECK (synctoken > 0) NOT NULL,
+    calendarid INT CHECK (calendarid > 0) NOT NULL,
+    operation SMALLINT NOT NULL
+);
+
+CREATE INDEX calendarid_synctoken ON calendarchanges (calendarid, synctoken);
+
+CREATE TABLE calendarsubscriptions (
+    id SERIAL PRIMARY KEY,
+    uri TEXT NOT NULL,
+    principaluri TEXT NOT NULL,
+    source TEXT,
+    displayname VARCHAR(100),
+    refreshrate VARCHAR(10),
+    calendarorder INT CHECK (calendarorder >= 0) NOT NULL DEFAULT '0',
+    calendarcolor TEXT,
+    striptodos SMALLINT NULL,
+    stripalarms SMALLINT NULL,
+    stripattachments SMALLINT NULL,
+    lastmodified INT CHECK (lastmodified > 0)
+);
+
+CREATE TABLE schedulingobjects (
+    id SERIAL PRIMARY KEY,
+    principaluri TEXT,
+    calendardata TEXT,
+    uri TEXT,
+    lastmodified INT CHECK (lastmodified > 0),
+    etag TEXT,
+    size INT CHECK (size > 0) NOT NULL
+);
+CREATE TABLE locks (
+    id SERIAL PRIMARY KEY,
+    owner VARCHAR(100),
+    timeout INTEGER CHECK (timeout > 0),
+    created INTEGER,
+    token TEXT,
+    scope SMALLINT,
+    depth SMALLINT,
+    uri TEXT
+);
+
+CREATE INDEX ON locks (token);
+CREATE INDEX ON locks (uri);
+
+CREATE TABLE principals (
+    id SERIAL PRIMARY KEY,
+    uri TEXT NOT NULL,
+    email TEXT,
+    displayname VARCHAR(80)
+);
+
+CREATE TABLE groupmembers (
+    id SERIAL PRIMARY KEY,
+    principal_id INTEGER CHECK (principal_id > 0) NOT NULL,
+    member_id INTEGER CHECK (member_id > 0) NOT NULL
+);
+
+CREATE TABLE propertystorage (
+    id SERIAL PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    valuetype INT CHECK (valuetype > 0),
+    value TEXT
+);
+
+CREATE UNIQUE INDEX path_property ON propertystorage (path, name);
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username TEXT,
+    digesta1 TEXT
+);

--- a/config/baikal.yaml.dist
+++ b/config/baikal.yaml.dist
@@ -11,9 +11,13 @@ system:
     base_uri: ''
 database:
     encryption_key: 5d3f0fa0192e3058ea70f1bb20924add
+    backend: 'mysql'
     sqlite_file: "absolute/path/to/Specific/db/db.sqlite"
-    mysql: true
     mysql_host: 'localhost'
     mysql_dbname: 'baikal'
     mysql_username: 'baikal'
     mysql_password: 'baikal'
+    pgsql_host: 'localhost'
+    pgsql_dbname: 'baikal'
+    pgsql_username: 'baikal'
+    pgsql_password: 'baikal'


### PR DESCRIPTION
This PR adds experimental PostgreSQL support.

Based upon [the work](https://github.com/dxtr/Baikal/tree/pgsql) of @dxtr, extended and adapted to the latest version of Baikal.

✅ **The following features were tested:**

- Baikal setup procedure / UI (with Postgres)
- Creating / deleting / editing a user
- Creating / deleting / editing a calendar
- Listing contacts
- Logging in / creating / deleting an event through the webui (User login)
- Subscribing to a calendar / adding / deleting an event through a DAV client
  - Thunderbird
  - DAVx⁵ for Android