### PR TITLE
chore: bump php-cs-fixer to 3.54.0

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,7 +7,9 @@ $config->getFinder()
 $config->setRules([
     '@PSR2' => true,
     '@Symfony' => true,
-    'binary_operator_spaces' => [],
+    'binary_operator_spaces' => [
+        'default' => 'at_least_single_space',
+    ],
     'braces_position' => [
         'functions_opening_brace' => 'same_line',
         'classes_opening_brace' => 'same_line'],

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-zlib"      : "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "3.52.1",
+        "friendsofphp/php-cs-fixer": "3.54.0",
         "phpstan/phpstan": "^1.10"
     },
     "replace" : {


### PR DESCRIPTION
Note php-cs-fixer now complains about 'binary_operator_spaces' being set to an empty array.
It wants the default setting to be explicitly mentioned.

```
$ composer cs-fixer
> php-cs-fixer fix
PHP CS Fixer 3.54.0 15 Keys Accelerate by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 7.4.3-4ubuntu2.20
Loaded config default from "/home/phil/git/sabre-io/Baikal/.php-cs-fixer.dist.php".
Using cache file ".php-cs-fixer.cache".
   0/117 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
In FixerFactory.php line 164:
                                                                                 
  [binary_operator_spaces] Configuration must be an array and may not be empty.  
                                                                                 

fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>...]

Script php-cs-fixer fix handling the cs-fixer event returned with error code 32
```

So I have chosen 'at_least_single_space' - that allows existing to pass cs-fixer.

The various settings options are mentioned here:
https://cs.symfony.com/doc/rules/operator/binary_operator_spaces.html