### PR TITLE
Fix login page url

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/Login.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Login.php
@@ -34,7 +34,7 @@ class Login extends \Flake\Core\Controller {
     }
 
     function render() {
-        $sActionUrl = PROJECT_BASEURI;
+        $sActionUrl = $GLOBALS["ROUTER"]::buildRoute("default", []);
         $sSubmittedFlagName = "auth";
         $sMessage = "";
 


### PR DESCRIPTION
Use Flake framework to get login url.
Otherwise slashes in the end of the urls are not handled correctly. Basically reverts 2ee4be608d9d353a1b82444c746855866fc7f883