### PR TITLE
Update dependencies, drop php 7.x and php 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         cs-fixer: [ true ]
-        include:
-          - php-versions: '7.2'
-            cs-fixer: false
-          - php-versions: '7.3'
-            cs-fixer: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist: vendor/autoload.php
 		$(BUILD_FILES) \
 		--exclude="*.swp" \
 		$(BUILD_DIR)
-	composer config platform.php 7.2 -d $(BUILD_DIR)
+	composer config platform.php 8.1 -d $(BUILD_DIR)
 	composer install --no-interaction --no-dev -d $(BUILD_DIR)
 	rm $(BUILD_DIR)/composer.*
 	cd build; zip -r baikal-$(VERSION).zip baikal/

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "homepage": "https://sabre.io/baikal/",
     "license" : "GPL-3.0-only",
     "require": {
-        "php"           : "^7.2 || ^8.0",
+        "php"           : "^8.1",
         "sabre/dav"     : "~4.7.0",
-        "twig/twig"     : "~3.8.0",
-        "symfony/yaml"  : "^5.4",
+        "twig/twig"     : "~3.14.0",
+        "symfony/yaml"  : "~6.4.13",
         "psr/log"       : "^1",
         "ext-dom"       : "*",
         "ext-openssl"   : "*",


### PR DESCRIPTION
php 7.x has stopped receiving security updates in the end of 2022.
php 8.0 has stopped receiving security updates in the end of 2023.

Upgrades twig/twig and symfony/yaml to versions that still support php 8.1, and pins their versions.