### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4', '8.5', '8.6']
         cs-fixer: [ true ]
     steps:
       - name: Checkout
@@ -48,7 +48,7 @@ jobs:
 
       - name: Code Analysis (PHP CS-Fixer)
         if: matrix.cs-fixer == true
-        run: php vendor/bin/php-cs-fixer fix --dry-run --diff
+        run: php vendor/bin/php-cs-fixer fix --dry-run --diff --allow-unsupported-php-version=yes
 
       - name: Code Analysis (PHPStan)
         run: composer phpstan

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,7 @@ $config->setRules([
         'functions_opening_brace' => 'same_line',
         'classes_opening_brace' => 'same_line'],
     'concat_space' => ['spacing' => 'one'],
+    'modifier_keywords' => ['elements' => []],
     'fully_qualified_strict_types' => false,
     'no_superfluous_phpdoc_tags' => false,
     'no_unneeded_control_parentheses' => false,
@@ -22,7 +23,6 @@ $config->setRules([
     'single_line_comment_spacing' => false,
     'single_quote' => false,
     'trailing_comma_in_multiline' => true,
-    'visibility_required' => false,
     'yoda_style' => false
 ]);
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dist: vendor/autoload.php
 		$(BUILD_FILES) \
 		--exclude="*.swp" \
 		$(BUILD_DIR)
-	composer config platform.php 8.1 -d $(BUILD_DIR)
+	composer config platform.php 8.2 -d $(BUILD_DIR)
 	composer install --no-interaction --no-dev -d $(BUILD_DIR)
 	rm $(BUILD_DIR)/composer.*
 	cd build; zip -r baikal-$(VERSION).zip baikal/

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php"           : "^8.1",
         "sabre/dav"     : "~4.7.0",
-        "twig/twig"     : "~3.14.0",
-        "symfony/yaml"  : "~6.4.13",
+        "twig/twig"     : "~3.22.0",
+        "symfony/yaml"  : "~7.3.5",
         "psr/log"       : "^1",
         "ext-dom"       : "*",
         "ext-openssl"   : "*",
@@ -17,8 +17,8 @@
         "ext-zlib"      : "*"
     },
     "require-dev" : {
-        "friendsofphp/php-cs-fixer": "3.65.0",
-        "phpstan/phpstan": "^1.10"
+        "friendsofphp/php-cs-fixer": "3.89.2",
+        "phpstan/phpstan": "~2.1.32"
     },
     "replace" : {
         "jeromeschneider/baikal" : "self.version"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
   level: 0
+  reportUnmatchedIgnoredErrors: false
   excludePaths:
     - Core/Frameworks/BaikalAdmin/Resources/GlyphiconsPro/generate-sprite.php
     - Core/Resources/Web/BaikalAdmin/GlyphiconsPro/generate-sprite.php
@@ -14,3 +15,5 @@ parameters:
     -
       message: '#Access to undefined constant Flake\\Core\\Model::LABELFIELD.#'
       path: Core/Frameworks/Flake/Core/Model.php
+    -
+      identifier: unset.possiblyHookedProperty


### PR DESCRIPTION
Drops support for php 8.1 because symfony/yaml v7.3.5 requires php >=8.2

Closes #1361