### PR TITLE
Use native php function for random bytes

### DIFF
--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -202,7 +202,7 @@ class Framework extends \Flake\Core\Framework {
                 session_start();
             }
             if (!isset($_SESSION['CSRF_TOKEN'])) {
-                $_SESSION['CSRF_TOKEN'] = bin2hex(openssl_random_pseudo_bytes(20));
+                $_SESSION['CSRF_TOKEN'] = bin2hex(random_bytes(20));
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "twig/twig"     : "~3.22.0",
         "symfony/yaml"  : "~7.3.5",
         "ext-dom"       : "*",
-        "ext-openssl"   : "*",
         "ext-pdo"       : "*",
         "ext-zlib"      : "*"
     },


### PR DESCRIPTION
### Changes

* Use native php function for random bytes
* Removes `openssl` dependency.

### Reference

fixes #1383
