### PR TITLE
Fix issues with CalDAV free-busy scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - master
       - release/*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   code-analysis:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -24,5 +24,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Baikal
-          path: build/baikal*.zip
-          archive: false
+          path: build/baikal
+          overwrite: true
+          include-hidden-files: true

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -20,3 +20,8 @@ jobs:
           php-version: 8.2
       - name: Build dist
         run: make dist
+      - name: Upload build file
+        uses: actions/upload-artifact@v4
+        with:
+          name: Baikal
+          path: build/baikal

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,7 +18,5 @@ jobs:
         uses: ./.github/actions/build
         with:
           php-version: 8.2
-      - name: Build assets
-        run: make build-assets
       - name: Build dist
         run: make dist

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,24 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP and Install Composer Dependencies
+        uses: ./.github/actions/build
+        with:
+          php-version: 8.2
+      - name: Build assets
+        run: make build-assets
+      - name: Build dist
+        run: make dist

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -23,6 +23,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Baikal
-          path: build/baikal
+          path: build/baikal/
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -24,4 +24,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Baikal
-          path: build/baikal
+          path: build/baikal*.zip
+          archive: false

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Baikal
-          path: build/baikal/
+          path: |
+            build/*
+            !build/baikal*.zip
           overwrite: true
           include-hidden-files: true

--- a/Core/Distrib.php
+++ b/Core/Distrib.php
@@ -25,5 +25,5 @@
 #  This copyright notice MUST APPEAR in all copies of the script!
 #################################################################
 
-define("BAIKAL_VERSION", "0.11.1");
+define("BAIKAL_VERSION", "0.12.1");
 define("BAIKAL_HOMEPAGE", "https://sabre.io/baikal/");

--- a/Core/Frameworks/Baikal/Core/FreeBusyPrincipalBackend.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusyPrincipalBackend.php
@@ -2,8 +2,7 @@
 
 namespace Baikal\Core;
 
-final class FreeBusyPrincipalBackend extends \Sabre\DAVACL\PrincipalBackend\PDO
-{
+final class FreeBusyPrincipalBackend extends \Sabre\DAVACL\PrincipalBackend\PDO {
     private array $temporaryProxyReadMembers = [];
 
     public function addTemporaryCalendarProxyRead(
@@ -14,13 +13,11 @@ final class FreeBusyPrincipalBackend extends \Sabre\DAVACL\PrincipalBackend\PDO
         $this->temporaryProxyReadMembers[$proxyPrincipal][$organizerPrincipal] = true;
     }
 
-    public function clearTemporaryCalendarProxyRead(): void
-    {
+    public function clearTemporaryCalendarProxyRead(): void {
         $this->temporaryProxyReadMembers = [];
     }
 
-    public function getGroupMemberSet($principal)
-    {
+    public function getGroupMemberSet($principal) {
         $members = parent::getGroupMemberSet($principal);
 
         if (isset($this->temporaryProxyReadMembers[$principal])) {
@@ -33,8 +30,7 @@ final class FreeBusyPrincipalBackend extends \Sabre\DAVACL\PrincipalBackend\PDO
         return array_values(array_unique($members));
     }
 
-    public function getGroupMembership($principal)
-    {
+    public function getGroupMembership($principal) {
         $groups = parent::getGroupMembership($principal);
 
         foreach ($this->temporaryProxyReadMembers as $proxyPrincipal => $members) {

--- a/Core/Frameworks/Baikal/Core/FreeBusyPrincipalBackend.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusyPrincipalBackend.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Baikal\Core;
+
+final class FreeBusyPrincipalBackend extends \Sabre\DAVACL\PrincipalBackend\PDO
+{
+    private array $temporaryProxyReadMembers = [];
+
+    public function addTemporaryCalendarProxyRead(
+        string $organizerPrincipal,
+        string $attendeePrincipal
+    ): void {
+        $proxyPrincipal = $attendeePrincipal . '/calendar-proxy-read';
+        $this->temporaryProxyReadMembers[$proxyPrincipal][$organizerPrincipal] = true;
+    }
+
+    public function clearTemporaryCalendarProxyRead(): void
+    {
+        $this->temporaryProxyReadMembers = [];
+    }
+
+    public function getGroupMemberSet($principal)
+    {
+        $members = parent::getGroupMemberSet($principal);
+
+        if (isset($this->temporaryProxyReadMembers[$principal])) {
+            $members = array_merge(
+                $members,
+                array_keys($this->temporaryProxyReadMembers[$principal])
+            );
+        }
+
+        return array_values(array_unique($members));
+    }
+
+    public function getGroupMembership($principal)
+    {
+        $groups = parent::getGroupMembership($principal);
+
+        foreach ($this->temporaryProxyReadMembers as $proxyPrincipal => $members) {
+            if (isset($members[$principal])) {
+                $groups[] = $proxyPrincipal;
+            }
+        }
+
+        return array_values(array_unique($groups));
+    }
+}

--- a/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
@@ -25,10 +25,15 @@ final class FreeBusySchedulePlugin extends Plugin {
             return parent::outboxRequest($outboxNode, $request, $response);
         }
 
-        $body = $request->getBody();
+        $body = $request->getBodyAsString();
         $vObject = Reader::read($body);
-        // Reset body so the parent can reuse it
-        $request->setBody($body);
+
+        $stream = fopen('php://temp', 'r+');
+        fwrite($stream, $body);
+        rewind($stream);
+
+        $request = clone $request;
+        $request->setBody($stream);
 
         try {
             if (!$this->isFreeBusyRequest($vObject)) {

--- a/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
@@ -27,6 +27,8 @@ final class FreeBusySchedulePlugin extends Plugin {
 
         $body = $request->getBody();
         $vObject = Reader::read($body);
+        // Reset body so the parent can reuse it
+        $request->setBody($body);
 
         try {
             if (!$this->isFreeBusyRequest($vObject)) {

--- a/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
@@ -9,8 +9,7 @@ use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component;
 use Sabre\VObject\Reader;
 
-final class FreeBusySchedulePlugin extends Plugin
-{
+final class FreeBusySchedulePlugin extends Plugin {
     public function __construct(
         private FreeBusyPrincipalBackend $principalBackend,
         private bool $allowFreeBusyLookup = true
@@ -50,15 +49,13 @@ final class FreeBusySchedulePlugin extends Plugin
         }
     }
 
-    private function isFreeBusyRequest(Component $vObject): bool
-    {
+    private function isFreeBusyRequest(Component $vObject): bool {
         return isset($vObject->METHOD)
             && strtoupper((string) $vObject->METHOD) === 'REQUEST'
             && isset($vObject->VFREEBUSY);
     }
 
-    private function getAttendeePrincipals(Component $vObject): array
-    {
+    private function getAttendeePrincipals(Component $vObject): array {
         $principals = [];
 
         if (!isset($vObject->VFREEBUSY->ATTENDEE)) {

--- a/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
+++ b/Core/Frameworks/Baikal/Core/FreeBusySchedulePlugin.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Baikal\Core;
+
+use Sabre\CalDAV\Schedule\IOutbox;
+use Sabre\CalDAV\Schedule\Plugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Component;
+use Sabre\VObject\Reader;
+
+final class FreeBusySchedulePlugin extends Plugin
+{
+    public function __construct(
+        private FreeBusyPrincipalBackend $principalBackend,
+        private bool $allowFreeBusyLookup = true
+    ) {
+    }
+
+    public function outboxRequest(
+        IOutbox $outboxNode,
+        RequestInterface $request,
+        ResponseInterface $response
+    ) {
+        if (!$this->allowFreeBusyLookup) {
+            return parent::outboxRequest($outboxNode, $request, $response);
+        }
+
+        $body = $request->getBody();
+        $vObject = Reader::read($body);
+
+        try {
+            if (!$this->isFreeBusyRequest($vObject)) {
+                return parent::outboxRequest($outboxNode, $request, $response);
+            }
+
+            $organizerPrincipal = $outboxNode->getOwner();
+
+            foreach ($this->getAttendeePrincipals($vObject) as $attendeePrincipal) {
+                $this->principalBackend->addTemporaryCalendarProxyRead(
+                    $organizerPrincipal,
+                    $attendeePrincipal
+                );
+            }
+
+            return parent::outboxRequest($outboxNode, $request, $response);
+        } finally {
+            $this->principalBackend->clearTemporaryCalendarProxyRead();
+            $vObject->destroy();
+        }
+    }
+
+    private function isFreeBusyRequest(Component $vObject): bool
+    {
+        return isset($vObject->METHOD)
+            && strtoupper((string) $vObject->METHOD) === 'REQUEST'
+            && isset($vObject->VFREEBUSY);
+    }
+
+    private function getAttendeePrincipals(Component $vObject): array
+    {
+        $principals = [];
+
+        if (!isset($vObject->VFREEBUSY->ATTENDEE)) {
+            return [];
+        }
+
+        foreach ($vObject->VFREEBUSY->ATTENDEE as $attendee) {
+            $uri = (string) $attendee;
+
+            $principal = $this->principalBackend->findByUri($uri, 'principals');
+            if ($principal !== null) {
+                $principals[] = $principal;
+            }
+        }
+
+        return array_values(array_unique($principals));
+    }
+}

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -138,7 +138,7 @@ class Server {
             $authBackend = new \Sabre\DAV\Auth\Backend\PDO($this->pdo);
             $authBackend->setRealm($this->authRealm);
         }
-        $principalBackend = new \Sabre\DAVACL\PrincipalBackend\PDO($this->pdo);
+        $principalBackend = new \Baikal\Core\FreeBusyPrincipalBackend($this->pdo);
 
         $nodes = [
             new \Sabre\CalDAV\Principal\Collection($principalBackend),
@@ -169,7 +169,10 @@ class Server {
         if ($this->enableCalDAV) {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-            $this->server->addPlugin(new \Sabre\CalDAV\Schedule\Plugin());
+            $this->server->addPlugin(new \Baikal\Core\FreeBusySchedulePlugin(
++                $principalBackend,
++                $config['system']['allow_free_busy_lookup'] ?? true
++            ));
             $this->server->addPlugin(new \Sabre\DAV\Sharing\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\SharingPlugin());
             if (isset($config['system']["invite_from"]) && $config['system']["invite_from"] !== "") {

--- a/Core/Frameworks/Baikal/Core/Server.php
+++ b/Core/Frameworks/Baikal/Core/Server.php
@@ -170,9 +170,9 @@ class Server {
             $this->server->addPlugin(new \Sabre\CalDAV\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
             $this->server->addPlugin(new \Baikal\Core\FreeBusySchedulePlugin(
-+                $principalBackend,
-+                $config['system']['allow_free_busy_lookup'] ?? true
-+            ));
+                $principalBackend,
+                $config['system']['allow_free_busy_lookup'] ?? true
+            ));
             $this->server->addPlugin(new \Sabre\DAV\Sharing\Plugin());
             $this->server->addPlugin(new \Sabre\CalDAV\SharingPlugin());
             if (isset($config['system']["invite_from"]) && $config['system']["invite_from"] !== "") {

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -27,6 +27,7 @@
 
 namespace Baikal\Model;
 
+use Sabre\VObject\Component\VCalendar;
 use Symfony\Component\Yaml\Yaml;
 
 class Calendar extends \Flake\Core\Model\Db {
@@ -52,7 +53,15 @@ class Calendar extends \Flake\Core\Model\Db {
         parent::__construct($sPrimary);
         try {
             $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
-            $this->set("timezone", $config['system']["timezone"]);
+            if (!empty($config['system']["timezone"])) {
+                $vcalendar = new VCalendar();
+                $vtimezone = $vcalendar->add('VTIMEZONE');
+                $vtimezone->add('TZID', $config['system']["timezone"]);
+                $this->set(
+                    "timezone",
+                    rtrim($vcalendar->serialize(),"\r\n")
+                );
+            }
         } catch (\Exception $e) {
             error_log('Error reading baikal.yaml file : ' . $e->getMessage());
         }

--- a/Core/Frameworks/Baikal/Model/Calendar.php
+++ b/Core/Frameworks/Baikal/Model/Calendar.php
@@ -59,7 +59,7 @@ class Calendar extends \Flake\Core\Model\Db {
                 $vtimezone->add('TZID', $config['system']["timezone"]);
                 $this->set(
                     "timezone",
-                    rtrim($vcalendar->serialize(),"\r\n")
+                    rtrim($vcalendar->serialize(), "\r\n")
                 );
             }
         } catch (\Exception $e) {

--- a/Core/Frameworks/Baikal/Model/User.php
+++ b/Core/Frameworks/Baikal/Model/User.php
@@ -132,6 +132,7 @@ class User extends \Flake\Core\Model\Db {
         # Persisted first, as Model users loads this data
         $this->oIdentityPrincipal->set("uri", "principals/" . $this->get("username"));
         $this->oIdentityPrincipal->persist();
+        $this->ensureCalendarProxyPrincipals();
 
         parent::persist();
 
@@ -286,5 +287,26 @@ class User extends \Flake\Core\Model\Db {
         }
 
         return md5($this->get("username") . ':' . $config['system']['auth_realm'] . ':' . $sPassword);
+    }
+
+    private function ensureCalendarProxyPrincipals(): void {
+        $baseUri = 'principals/' . $this->get('username');
+
+        foreach (['calendar-proxy-read', 'calendar-proxy-write'] as $proxy) {
+            $uri = $baseUri . '/' . $proxy;
+
+            $existing = \Baikal\Model\Principal::getBaseRequester()
+                ->addClauseEquals('uri', $uri)
+                ->execute()
+                ->first();
+
+            if ($existing) {
+                continue;
+            }
+
+            $principal = new \Baikal\Model\Principal();
+            $principal->set('uri', $uri);
+            $principal->persist();
+        }
     }
 }

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -513,6 +513,38 @@ SQL
             $oConfig->persist();
         }
 
+        if (version_compare($sVersionFrom, '0.11.1', '<')) {
+            $select = $pdo->query("
+                SELECT uri
+                FROM principals
+                WHERE uri NOT LIKE '%/calendar-proxy-read'
+                AND uri NOT LIKE '%/calendar-proxy-write'
+            ");
+
+            $exists = $pdo->prepare("
+                SELECT id
+                FROM principals
+                WHERE uri = ?
+            ");
+
+            $insert = $pdo->prepare("
+                INSERT INTO principals (uri, email, displayname)
+                VALUES (?, NULL, NULL)
+            ");
+
+            foreach ($select->fetchAll(\PDO::FETCH_COLUMN) as $principalUri) {
+                foreach (['calendar-proxy-read', 'calendar-proxy-write'] as $proxy) {
+                    $proxyUri = $principalUri . '/' . $proxy;
+
+                    $exists->execute([$proxyUri]);
+                    if ($exists->fetchColumn() !== false) {
+                        continue;
+                    }
+
+                    $insert->execute([$proxyUri]);
+                }
+            }
+
         $this->updateConfiguredVersion($sVersionTo);
 
         return true;

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -546,6 +546,44 @@ SQL
                     $this->aSuccess[] = $proxy . ' added for principal ' . $principalUri;
                 }
             }
+            
+            $select = $pdo->query("
+                SELECT id, timezone
+                FROM calendarinstances
+                WHERE timezone IS NOT NULL
+                AND timezone != ''
+                AND timezone NOT LIKE 'BEGIN:VCALENDAR%'
+            ");
+
+            $update = $pdo->prepare("
+                UPDATE calendarinstances
+                SET timezone = ?
+                WHERE id = ?
+            ");
+
+            $count = 0;
+
+            while ($row = $select->fetch(\PDO::FETCH_ASSOC)) {
+                $timezone = trim($row['timezone']);
+
+                if ($timezone === '') {
+                    continue;
+                }
+
+                $vcalendar = new \Sabre\VObject\Component\VCalendar();
+                $vtimezone = $vcalendar->add('VTIMEZONE');
+                $vtimezone->add('TZID', $timezone);
+
+                $update->execute([
+                    rtrim($vcalendar->serialize(), "\r\n"),
+                    $row['id'],
+                ]);
+
+                ++$count;
+                $vcalendar->destroy();
+
+            $this->aSuccess[] = 'Migrated ' . $count . ' calendar timezone value(s) to VCALENDAR format';
+            }
         }
 
         $this->updateConfiguredVersion($sVersionTo);

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -513,7 +513,8 @@ SQL
             $oConfig->persist();
         }
 
-        if (version_compare($sVersionFrom, '0.11.1', '<')) {
+        if (version_compare($sVersionFrom, '0.12.1', '<')) {
+            $this->aSuccess[] = 'Adding calendar-proxy-read and -write...';
             $select = $pdo->query("
                 SELECT uri
                 FROM principals
@@ -542,6 +543,7 @@ SQL
                     }
 
                     $insert->execute([$proxyUri]);
+                    $this->aSuccess[] = $proxy . ' added for principal ' . $principalUri;
                 }
             }
         }

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -544,6 +544,7 @@ SQL
                     $insert->execute([$proxyUri]);
                 }
             }
+        }
 
         $this->updateConfiguredVersion($sVersionTo);
 

--- a/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/VersionUpgrade.php
@@ -546,7 +546,7 @@ SQL
                     $this->aSuccess[] = $proxy . ' added for principal ' . $principalUri;
                 }
             }
-            
+
             $select = $pdo->query("
                 SELECT id, timezone
                 FROM calendarinstances
@@ -582,7 +582,7 @@ SQL
                 ++$count;
                 $vcalendar->destroy();
 
-            $this->aSuccess[] = 'Migrated ' . $count . ' calendar timezone value(s) to VCALENDAR format';
+                $this->aSuccess[] = 'Migrated ' . $count . ' calendar timezone value(s) to VCALENDAR format';
             }
         }
 

--- a/config/baikal.yaml.dist
+++ b/config/baikal.yaml.dist
@@ -9,6 +9,7 @@ system:
     failed_access_message: 'user %u authentication failure for Baikal'
     auth_realm: BaikalDAV
     base_uri: ''
+    allow_free_busy_lookup: true
 database:
     encryption_key: 5d3f0fa0192e3058ea70f1bb20924add
     backend: 'mysql'


### PR DESCRIPTION
## Summary

This PR adds support for CalDAV free-busy scheduling by introducing temporary virtual `calendar-proxy-read` membership during free-busy outbox requests. It also creates required calendar proxy principals for new and existing users, updates timezone storage for newly created calendars, and adds CI support for building distribution artifacts.

## Changes

- Add `FreeBusyPrincipalBackend` to support temporary `calendar-proxy-read` membership during a request.
- Add `FreeBusySchedulePlugin` to detect `VFREEBUSY` scheduling requests and grant temporary proxy-read access only while handling the outbox POST.
- Replace the default Sabre schedule plugin wiring with the new Baikal free-busy schedule plugin.
- Add `allow_free_busy_lookup` configuration option, enabled by default.
- Create `calendar-proxy-read` and `calendar-proxy-write` principals for newly created users.
- Add upgrade migration to backfill proxy principals for existing users when upgrading to `0.12.1`.
- Store configured calendar timezone as a proper `VCALENDAR` / `VTIMEZONE` object instead of a plain string.
- Bump Baikal version from `0.11.1` to `0.12.1`.
- Add a GitHub Actions workflow to build distribution artifacts with `make dist`.
- Enable manual workflow dispatch for the existing CI workflow.

## Motivation

Free-busy lookups need limited access to attendee calendar availability data, but this access should not become permanent group membership. This change grants temporary proxy-read membership only for the organizer principal and only for the duration of the free-busy request.

## Solved issues
Fixes: #1360, #697 and #982 

## Testing 
Tested with Thunderbird on Baikal running on docker without the `APPLY_HOME_ASSISTANT_FIX` set to `TRUE`. 

I haven't tested it with the home-assistant but based on the comments the issue was a wrong timezone handling (string instead of `VOBJECT`), which is fixed here.
