### PR TITLE
Updated runtime dependencies

### DIFF
--- a/Core/Frameworks/Flake/Core/Database/Mysql.php
+++ b/Core/Frameworks/Flake/Core/Database/Mysql.php
@@ -46,7 +46,7 @@ class Mysql extends \Flake\Core\Database {
         ];
 
         if ($this->sCaCert !== "") {
-             if (PHP_VERSION_ID >= 80500) {
+            if (PHP_VERSION_ID >= 80500) {
                 // PHP 8.5+
                 // @phpstan-ignore class.notFound
                 $options[\Pdo\Mysql::ATTR_SSL_CA] = $this->sCaCert;

--- a/Core/Frameworks/Flake/Core/Database/Mysql.php
+++ b/Core/Frameworks/Flake/Core/Database/Mysql.php
@@ -46,7 +46,14 @@ class Mysql extends \Flake\Core\Database {
         ];
 
         if ($this->sCaCert !== "") {
-            $options[\PDO::MYSQL_ATTR_SSL_CA] = $this->sCaCert;
+             if (PHP_VERSION_ID >= 80500) {
+                // PHP 8.5+
+                // @phpstan-ignore class.notFound
+                $options[\Pdo\Mysql::ATTR_SSL_CA] = $this->sCaCert;
+            } else {
+                // @phpstan-ignore class.notFound
+                $options[\PDO::MYSQL_ATTR_SSL_CA] = $this->sCaCert;
+            }
         }
 
         $this->oDb = new \PDO(

--- a/Core/Frameworks/Flake/Core/Database/Mysql.php
+++ b/Core/Frameworks/Flake/Core/Database/Mysql.php
@@ -46,14 +46,13 @@ class Mysql extends \Flake\Core\Database {
         ];
 
         if ($this->sCaCert !== "") {
-            if (PHP_VERSION_ID >= 80500) {
-                // PHP 8.5+
-                // @phpstan-ignore class.notFound
-                $options[\Pdo\Mysql::ATTR_SSL_CA] = $this->sCaCert;
-            } else {
-                // @phpstan-ignore class.notFound
-                $options[\PDO::MYSQL_ATTR_SSL_CA] = $this->sCaCert;
-            }
+            // PDO::MYSQL_ATTR_SSL_CA was deprecated in PHP 8.4 in favour of PDO\Mysql::ATTR_SSL_CA.
+            // Use constant() to resolve the right name at runtime without a direct reference to
+            // the deprecated constant, keeping compatibility with PHP 8.2 and 8.3.
+            $sslCaAttr = defined('PDO\Mysql::ATTR_SSL_CA')
+                ? constant('PDO\Mysql::ATTR_SSL_CA')
+                : constant('PDO::MYSQL_ATTR_SSL_CA');
+            $options[$sslCaAttr] = $this->sCaCert;
         }
 
         $this->oDb = new \PDO(

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require-dev" : {
         "friendsofphp/php-cs-fixer": "3.89.2",
-        "phpstan/phpstan": "~2.1.33",
-        "phpstan/phpstan-deprecation-rules": "~2.0.3"
+        "phpstan/phpstan": "2.1.53",
+        "phpstan/phpstan-deprecation-rules": "2.0.4"
     },
     "replace" : {
         "jeromeschneider/baikal" : "self.version"

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "require": {
         "php"           : "^8.2",
         "sabre/dav"     : "~4.7.0",
-        "twig/twig"     : "~3.22.0",
-        "symfony/yaml"  : "~7.3.5",
+        "twig/twig"     : "~3.24.0",
+        "symfony/yaml"  : "~7.4.8",
         "ext-dom"       : "*",
         "ext-pdo"       : "*",
         "ext-zlib"      : "*"


### PR DESCRIPTION
It makes sense to have a Symfony dependency that's not EOL. (8.0.x is available, but I did not want to introduce breaking changes yet. I still plan to upgrade Baikal to Bootstrap 5 some time soon, because Bootstrap 2 has quite a few security implications, but that would be a larger update...) Also, updated Twig because why not.

This should not break things.