### PR TITLE
Detect missing XMLReader class in assertEnvironmentIsOk

### DIFF
--- a/Core/Frameworks/Baikal/Core/Tools.php
+++ b/Core/Frameworks/Baikal/Core/Tools.php
@@ -49,6 +49,13 @@ class Tools {
             exit('<strong>Baikal Fatal Error</strong>: None of <strong>PDO::sqlite</strong>, <strong>PDO::mysql</strong> or <strong>PDO::pgsql</strong> are available. One of them at least is required by Baikal.');
         }
 
+        # Asserting XMLReader is available
+        # Without it, the install tool and admin GUI still work, but every CalDAV/CardDAV
+        # request fails deep inside sabre/xml with 'Class "XMLReader" not found'.
+        if (!class_exists('XMLReader')) {
+            exit('<strong>Baikal Fatal Error</strong>: The <strong>XMLReader</strong> class is unavailable. The <strong>xml</strong> PHP extension is required by Baikal.');
+        }
+
         # Assert that the temp folder is writable
         if (!\is_writable(\sys_get_temp_dir())) {
             exit('<strong>Baikal Fatal Error</strong>: The system temp directory is not writable.');


### PR DESCRIPTION
## Problem

When the PHP `xml` extension (providing `XMLReader`) is missing, the install tool and admin GUI work fine — they don't parse XML — so the server looks healthy. But every CalDAV/CardDAV request then 500s deep inside sabre/xml:

    Error: Class "XMLReader" not found in .../vendor/sabre/xml/lib/Reader.php

`Baikal\Core\Tools::assertEnvironmentIsOk()` already guards PDO, a database driver and a writable temp dir, but not this required class, so the misconfiguration is only discovered as a cryptic 500 in the web server log.

## Fix

Assert that `XMLReader` is available during bootstrap (the check already runs on every entry point via `Baikal\Framework::bootstrap()`), failing early with a clear message instead of a runtime 500.

This is a runtime guard on purpose: Baikal ships as a pre-built archive with vendored dependencies, so Composer's platform requirements never run on the end user's host.

## Verification

- `php -l` clean; `php-cs-fixer` (dry-run) reports no changes; `phpstan analyse Core html` reports no errors.
- With `XMLReader` present, `assertEnvironmentIsOk()` still passes and boot continues.
- With `XMLReader` unavailable, bootstrap now stops with the new message before reaching sabre/xml.

Fixes #1184

---
Disclosure: this change was prepared with the assistance of an AI agent (Claude) and reviewed before submission.
