### PR TITLE
fix: utf8mb Connection for Emojis

### DIFF
--- a/Core/Frameworks/Flake/Framework.php
+++ b/Core/Frameworks/Flake/Framework.php
@@ -336,7 +336,7 @@ class Framework extends \Flake\Core\Framework {
             );
 
             # We now setup the connection to use UTF8
-            $GLOBALS["DB"]->query("SET NAMES UTF8");
+            $GLOBALS["DB"]->query("SET NAMES utf8mb4");
         } catch (\Exception $e) {
             exit("<h3>Ba&iuml;kal was not able to establish a connection to the configured MySQL database (as configured in config/baikal.yaml).</h3>");
         }


### PR DESCRIPTION
This PR fixes https://github.com/sabre-io/Baikal/issues/1423
As it looks like the connection currently falls back to utf8mb3 instead of 4. 
I did not check why or if something was removed/changed since the 0.9.3 version.