### PR TITLE
Reduce space consumption

### DIFF
--- a/Core/Resources/Web/Bootstrap
+++ b/Core/Resources/Web/Bootstrap
@@ -1,1 +1,0 @@
-../../../vendor/twbs/bootstrap/dist

--- a/Core/Resources/Web/Bootstrap/css/bootstrap.min.css
+++ b/Core/Resources/Web/Bootstrap/css/bootstrap.min.css
@@ -1,0 +1,1 @@
+../../../../../vendor/twbs/bootstrap/dist/css/bootstrap.min.css

--- a/Core/Resources/Web/Bootstrap/js/bootstrap.bundle.min.js
+++ b/Core/Resources/Web/Bootstrap/js/bootstrap.bundle.min.js
@@ -1,0 +1,1 @@
+../../../../../vendor/twbs/bootstrap/dist/js/bootstrap.bundle.min.js

--- a/Core/Resources/Web/FontAwesome
+++ b/Core/Resources/Web/FontAwesome
@@ -1,1 +1,0 @@
-../../../vendor/fortawesome/font-awesome

--- a/Core/Resources/Web/FontAwesome/css/all.min.css
+++ b/Core/Resources/Web/FontAwesome/css/all.min.css
@@ -1,0 +1,1 @@
+../../../../../vendor/fortawesome/font-awesome/css/all.min.css

--- a/Core/Resources/Web/FontAwesome/webfonts/fa-brands-400.woff2
+++ b/Core/Resources/Web/FontAwesome/webfonts/fa-brands-400.woff2
@@ -1,0 +1,1 @@
+../../../../../vendor/fortawesome/font-awesome/webfonts/fa-brands-400.woff2

--- a/Core/Resources/Web/FontAwesome/webfonts/fa-regular-400.woff2
+++ b/Core/Resources/Web/FontAwesome/webfonts/fa-regular-400.woff2
@@ -1,0 +1,1 @@
+../../../../../vendor/fortawesome/font-awesome/webfonts/fa-regular-400.woff2

--- a/Core/Resources/Web/FontAwesome/webfonts/fa-solid-900.woff2
+++ b/Core/Resources/Web/FontAwesome/webfonts/fa-solid-900.woff2
@@ -1,0 +1,1 @@
+../../../../../vendor/fortawesome/font-awesome/webfonts/fa-solid-900.woff2

--- a/Core/Resources/Web/FontAwesome/webfonts/fa-v4compatibility.woff2
+++ b/Core/Resources/Web/FontAwesome/webfonts/fa-v4compatibility.woff2
@@ -1,1 +1,0 @@
-../../../../../vendor/fortawesome/font-awesome/webfonts/fa-v4compatibility.woff2

--- a/Core/Resources/Web/FontAwesome/webfonts/fa-v4compatibility.woff2
+++ b/Core/Resources/Web/FontAwesome/webfonts/fa-v4compatibility.woff2
@@ -1,0 +1,1 @@
+../../../../../vendor/fortawesome/font-awesome/webfonts/fa-v4compatibility.woff2

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ dist: vendor/autoload.php
 	composer config platform.php 8.2 -d $(BUILD_DIR)
 	composer install --no-interaction --no-dev -d $(BUILD_DIR)
 	rm $(BUILD_DIR)/composer.*
-	cd build; zip -r baikal-$(VERSION).zip baikal/
+	# inline symlinks
+	find $(BUILD_DIR) -type l -exec sh -c 'target=$$(readlink -f "$$1"); rm "$$1"; cp -rL "$$target" "$$1"' _ {} \;
+	rm -r $(BUILD_DIR)/vendor/twbs/bootstrap $(BUILD_DIR)/vendor/fortawesome/font-awesome
+	cd build; zip -ry baikal-$(VERSION).zip baikal/
 
 build-assets: vendor/autoload.php
 	cat vendor/sabre/dav/examples/sql/mysql.*.sql > Core/Resources/Db/MySQL/db.sql


### PR DESCRIPTION
Only symlink to the actual files we need, not the whole vendor folder. The makefile now inlines symlinks in a more explicit way.

Closes #1429