### PR TITLE
Add CSRF check to installation wizard

### DIFF
--- a/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
+++ b/Core/Frameworks/BaikalAdmin/Controller/Install/Database.php
@@ -64,7 +64,9 @@ class Database extends \Flake\Core\Controller {
                 if (file_exists(PROJECT_PATH_SPECIFIC . "config.system.php")) {
                     @unlink(PROJECT_PATH_SPECIFIC . "config.system.php");
                 }
-                touch(PROJECT_PATH_SPECIFIC . '/INSTALL_DISABLED');
+                if (!touch(PROJECT_PATH_SPECIFIC . '/INSTALL_DISABLED')) {
+                    exit('<h1>Error - Insufficient permissions on the configuration folder</h1><p>The database was configured, but Ba&iuml;kal could not create <strong>' . htmlspecialchars(PROJECT_PATH_SPECIFIC) . 'INSTALL_DISABLED</strong>, which is required to close the install wizard. Please make the <strong>Specific/</strong> folder writable and reload this page.</p>');
+                }
 
                 if (defined("BAIKAL_CONFIGURED_VERSION")) {
                     $oStandardConfig = new \Baikal\Model\Config\Standard();

--- a/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
+++ b/Core/Frameworks/BaikalAdmin/WWWRoot/install/index.php
@@ -68,6 +68,16 @@ $oPage->setBaseUrl(PROJECT_URI);
 
 $oPage->zone("navbar")->addBlock(new \BaikalAdmin\Controller\Navigation\Topbar\Install());
 
+// CSRF token check
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['CSRF_TOKEN'])) {
+        throw new \Exception('CSRF token was not submitted. Try removing your cookies and reloading the page.');
+    }
+    if ($_POST['CSRF_TOKEN'] !== $_SESSION['CSRF_TOKEN']) {
+        throw new \Exception('CSRF token did not match the session CSRF token. Please try to do this action again.');
+    }
+}
+
 try {
     $config = Yaml::parseFile(PROJECT_PATH_CONFIG . "baikal.yaml");
 } catch (\Exception $e) {
@@ -83,6 +93,7 @@ if (!$config || !isset($config['system']["configured_version"])) {
     $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Install\Initialize());
 } else {
     if ($config['system']["configured_version"] !== BAIKAL_VERSION) {
+        # No auth check: the login page itself redirects here, and upgrading is safe.
         # we have to upgrade Baïkal
         if (\Flake\Util\Tools::GET("upgradeConfirmed")) {
             $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Install\VersionUpgrade());
@@ -90,6 +101,7 @@ if (!$config || !isset($config['system']["configured_version"])) {
             $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Install\UpgradeConfirmation());
         }
     } elseif (!file_exists(PROJECT_PATH_SPECIFIC . '/INSTALL_DISABLED')) {
+        # No auth check: reachable during the installation wizard, disabled afterwards.
         $oPage->zone("Payload")->addBlock(new \BaikalAdmin\Controller\Install\Database());
     } else {
         echo "Installation was already completed. Please head to the admin interface to modify any settings.\n";


### PR DESCRIPTION
This is mainly to make security scanners happy. It is very unlikely for someone to start a CSRF attack in the short time while you are already in the Baikal installation wizard. After the install is complete, the wizard is disabled.